### PR TITLE
Remove `@matrixai/quic` and `@matrixai/id` and separate error tree

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -23,7 +23,6 @@ const globals = {
   ),
   // Default asynchronous test timeout
   defaultTimeout: 20000,
-  polykeyStartupTimeout: 30000,
   failedConnectionTimeout: 50000,
   // Timeouts rely on setTimeout which takes 32 bit numbers
   maxTimeout: Math.pow(2, 31) - 1,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,10 @@
     "": {
       "name": "polykey-cli",
       "version": "0.0.1",
-      "license": "Apache-2.0",
+      "license": "GPL-3.0",
       "dependencies": {
         "@matrixai/errors": "^1.1.7",
-        "@matrixai/id": "^3.3.6",
         "@matrixai/logger": "^3.1.0",
-        "@matrixai/quic": "^0.0.12",
         "commander": "^8.3.0",
         "polykey": "^1.1.5-alpha.0",
         "threads": "^1.6.5"
@@ -48,6 +46,7 @@
         "ts-jest": "^28.0.5",
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^3.9.0",
+        "tsx": "^3.12.7",
         "typedoc": "^0.23.21",
         "typescript": "^4.9.3"
       }
@@ -659,6 +658,398 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@esbuild-kit/cjs-loader": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/cjs-loader/-/cjs-loader-2.4.2.tgz",
+      "integrity": "sha512-BDXFbYOJzT/NBEtp71cvsrGPwGAMGRB/349rwKuoxNSiKjPraNNnlK6MIIabViCjqZugu6j+xeMDlEkWdHHJSg==",
+      "dev": true,
+      "dependencies": {
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "get-tsconfig": "^4.4.0"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.1.0.tgz",
+      "integrity": "sha512-Uuk8RpCg/7fdHSceR1M6XbSZFSuMrxcePFuGgyvsBn+u339dk5OeL4jv2EojwTN2st/unJGsVm4qHWjWNmJ/tw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.17.6",
+        "source-map-support": "^0.5.21"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/@esbuild-kit/esm-loader": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.5.5.tgz",
+      "integrity": "sha512-Qwfvj/qoPbClxCRNuac1Du01r9gvNOT+pMYtJDapfB1eoGN1YlJ1BixLyL9WVENRx5RXgNLdfYdx/CuswlGhMw==",
+      "dev": true,
+      "dependencies": {
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "get-tsconfig": "^4.4.0"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1318,14 +1709,14 @@
       "integrity": "sha512-C4JWpgbNik3V99bfGfDell5cH3JULD67eEq9CeXl4rYgsvanF8hhuY84ZYvndPhimt9qjA9/Z8uExKGoiv1zVw=="
     },
     "node_modules/@matrixai/quic": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic/-/quic-0.0.12.tgz",
-      "integrity": "sha512-aEh21BIgBGqI9IVVAzJF5h/Wu35jmTU35pKLsCJq38wv+1uEbjvWQw3O6oykahHD/2TXwy9ki367lGqOz4ejnw==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic/-/quic-0.0.14.tgz",
+      "integrity": "sha512-FINNs92u0qKXHRmBbUePODEx67IAzVr0XgmMARLGcyMRC3rAuQN0L0fsXJTxokcUqO1aaIYurGhzY4kVwtHW8Q==",
       "dependencies": {
-        "@matrixai/async-cancellable": "^1.1.0",
+        "@matrixai/async-cancellable": "^1.1.1",
         "@matrixai/async-init": "^1.8.4",
         "@matrixai/async-locks": "^4.0.0",
-        "@matrixai/contexts": "^1.0.0",
+        "@matrixai/contexts": "^1.1.0",
         "@matrixai/errors": "^1.1.7",
         "@matrixai/logger": "^3.1.0",
         "@matrixai/resources": "^1.1.5",
@@ -1333,16 +1724,40 @@
         "ip-num": "^1.5.0"
       },
       "optionalDependencies": {
-        "@matrixai/quic-darwin-arm64": "0.0.12",
-        "@matrixai/quic-darwin-x64": "0.0.12",
-        "@matrixai/quic-linux-x64": "0.0.12",
-        "@matrixai/quic-win32-x64": "0.0.12"
+        "@matrixai/quic-darwin-arm64": "0.0.14",
+        "@matrixai/quic-darwin-x64": "0.0.14",
+        "@matrixai/quic-linux-x64": "0.0.14",
+        "@matrixai/quic-win32-x64": "0.0.14"
       }
     },
+    "node_modules/@matrixai/quic-darwin-arm64": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-arm64/-/quic-darwin-arm64-0.0.14.tgz",
+      "integrity": "sha512-cdC6m02aaqKZi0dOulLhTFYNUALqnptsHzgFCwOU2uwiEbBghIkC/gjrPMpj4KmReb55ZZ5z2cap8KrQCcD0Cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@matrixai/quic-darwin-x64": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-x64/-/quic-darwin-x64-0.0.14.tgz",
+      "integrity": "sha512-zvkGeBGFgOKSXnHFcqZyEqmam6ZhvjKXi5oTp5nzYqGw2lf6KorruEmdQoi414fOZwB+uEvTZuH15rCapvZO2w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
     "node_modules/@matrixai/quic-linux-x64": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-linux-x64/-/quic-linux-x64-0.0.12.tgz",
-      "integrity": "sha512-WVS0j0D0UJPGe4q4gVHCppoJ5I6BN4oBTsKKMxMz92g7P9kzx/0JBaEVhHdIJTrxlGDzlKAt9RtZe5hvq/UtpA==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-linux-x64/-/quic-linux-x64-0.0.14.tgz",
+      "integrity": "sha512-t6kCv7Cg9ef6rVMWyH4/mkcRTsxgusXSO+ivlysCOiTK6R+LasTLelzjnWvUvJXfCgY9cJHn7JsZuQsdf/SB0g==",
       "cpu": [
         "x64"
       ],
@@ -3398,6 +3813,43 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.19",
+        "@esbuild/android-arm64": "0.17.19",
+        "@esbuild/android-x64": "0.17.19",
+        "@esbuild/darwin-arm64": "0.17.19",
+        "@esbuild/darwin-x64": "0.17.19",
+        "@esbuild/freebsd-arm64": "0.17.19",
+        "@esbuild/freebsd-x64": "0.17.19",
+        "@esbuild/linux-arm": "0.17.19",
+        "@esbuild/linux-arm64": "0.17.19",
+        "@esbuild/linux-ia32": "0.17.19",
+        "@esbuild/linux-loong64": "0.17.19",
+        "@esbuild/linux-mips64el": "0.17.19",
+        "@esbuild/linux-ppc64": "0.17.19",
+        "@esbuild/linux-riscv64": "0.17.19",
+        "@esbuild/linux-s390x": "0.17.19",
+        "@esbuild/linux-x64": "0.17.19",
+        "@esbuild/netbsd-x64": "0.17.19",
+        "@esbuild/openbsd-x64": "0.17.19",
+        "@esbuild/sunos-x64": "0.17.19",
+        "@esbuild/win32-arm64": "0.17.19",
+        "@esbuild/win32-ia32": "0.17.19",
+        "@esbuild/win32-x64": "0.17.19"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -4121,6 +4573,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.0.tgz",
+      "integrity": "sha512-pmjiZ7xtB8URYm74PlGJozDNyhvsVLUcpBa8DZBG3bWHwaHa9bPiRpiSfovw+fjhwONSCWKRyk+JQHEGZmMrzw==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/github-from-package": {
@@ -6846,9 +7310,9 @@
       }
     },
     "node_modules/polykey": {
-      "version": "1.1.5-alpha.0",
-      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.1.5-alpha.0.tgz",
-      "integrity": "sha512-jVNKcxgjYpjVpuBBOJ42/k3f4gW/tsJvMA/h+NAIp0Swt1nGSPgAy58lrIDFLd5t+frWmLrb9qEyutiR++cESw==",
+      "version": "1.1.5-feature-agent-migration-stage2.0",
+      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.1.5-feature-agent-migration-stage2.0.tgz",
+      "integrity": "sha512-t95OB8FI5zMJlXqn5q6FNgnJLlJ0VXpucf6NSQXkUyaKdw81XszQaDhs2mZIie7MBTlhg6kmmJohJL1cXadn1g==",
       "dependencies": {
         "@matrixai/async-cancellable": "^1.1.1",
         "@matrixai/async-init": "^1.8.4",
@@ -6858,7 +7322,7 @@
         "@matrixai/errors": "^1.1.7",
         "@matrixai/id": "^3.3.6",
         "@matrixai/logger": "^3.1.0",
-        "@matrixai/quic": "^0.0.13",
+        "@matrixai/quic": "^0.0.14",
         "@matrixai/resources": "^1.1.5",
         "@matrixai/timer": "^1.1.1",
         "@matrixai/workers": "^1.3.7",
@@ -6873,7 +7337,6 @@
         "ajv": "^7.0.4",
         "canonicalize": "^1.0.5",
         "cheerio": "^1.0.0-rc.5",
-        "commander": "^8.3.0",
         "cross-fetch": "^3.0.6",
         "cross-spawn": "^7.0.3",
         "encryptedfs": "^3.5.6",
@@ -6890,44 +7353,8 @@
         "resource-counter": "^1.2.4",
         "sodium-native": "^3.4.1",
         "threads": "^1.6.5",
-        "tslib": "^2.4.0",
-        "tsyringe": "^4.7.0",
         "ws": "^8.12.0"
       }
-    },
-    "node_modules/polykey/node_modules/@matrixai/quic": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic/-/quic-0.0.13.tgz",
-      "integrity": "sha512-tvlA0m2fUIchyEZxzkBbvYNXYf21u0gR4Lv2BaYZYmGa1Fr2VH07MCZu9Ka8DpAEOXKEU94yqhNSEKCCJ83LJA==",
-      "dependencies": {
-        "@matrixai/async-cancellable": "^1.1.0",
-        "@matrixai/async-init": "^1.8.4",
-        "@matrixai/async-locks": "^4.0.0",
-        "@matrixai/contexts": "^1.0.0",
-        "@matrixai/errors": "^1.1.7",
-        "@matrixai/logger": "^3.1.0",
-        "@matrixai/resources": "^1.1.5",
-        "@matrixai/timer": "^1.1.1",
-        "ip-num": "^1.5.0"
-      },
-      "optionalDependencies": {
-        "@matrixai/quic-darwin-arm64": "0.0.13",
-        "@matrixai/quic-darwin-x64": "0.0.13",
-        "@matrixai/quic-linux-x64": "0.0.13",
-        "@matrixai/quic-win32-x64": "0.0.13"
-      }
-    },
-    "node_modules/polykey/node_modules/@matrixai/quic-linux-x64": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-linux-x64/-/quic-linux-x64-0.0.13.tgz",
-      "integrity": "sha512-ExOhO9YjiCNV6OrRMF2+CVQdPANa2zSqlMzCUaLC5whAsll50M08LpoV4J/HnmpTWPcfohr+G28bFWVsnb8/wA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
     },
     "node_modules/polykey/node_modules/ajv": {
       "version": "7.2.4",
@@ -7306,6 +7733,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/resolve.exports": {
@@ -8139,6 +8575,23 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
+    },
+    "node_modules/tsx": {
+      "version": "3.12.7",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.12.7.tgz",
+      "integrity": "sha512-C2Ip+jPmqKd1GWVQDvz/Eyc6QJbGfE7NrR3fx5BpEHMZsEHoIxHL1j+lKdGobr8ovEyqeNkPLSKp6SCSOt7gmw==",
+      "dev": true,
+      "dependencies": {
+        "@esbuild-kit/cjs-loader": "^2.4.2",
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "@esbuild-kit/esm-loader": "^2.5.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.js"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
     },
     "node_modules/tsyringe": {
       "version": "4.8.0",
@@ -9124,6 +9577,202 @@
         }
       }
     },
+    "@esbuild-kit/cjs-loader": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/cjs-loader/-/cjs-loader-2.4.2.tgz",
+      "integrity": "sha512-BDXFbYOJzT/NBEtp71cvsrGPwGAMGRB/349rwKuoxNSiKjPraNNnlK6MIIabViCjqZugu6j+xeMDlEkWdHHJSg==",
+      "dev": true,
+      "requires": {
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "get-tsconfig": "^4.4.0"
+      }
+    },
+    "@esbuild-kit/core-utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.1.0.tgz",
+      "integrity": "sha512-Uuk8RpCg/7fdHSceR1M6XbSZFSuMrxcePFuGgyvsBn+u339dk5OeL4jv2EojwTN2st/unJGsVm4qHWjWNmJ/tw==",
+      "dev": true,
+      "requires": {
+        "esbuild": "~0.17.6",
+        "source-map-support": "^0.5.21"
+      },
+      "dependencies": {
+        "source-map-support": {
+          "version": "0.5.21",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+          "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
+      }
+    },
+    "@esbuild-kit/esm-loader": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.5.5.tgz",
+      "integrity": "sha512-Qwfvj/qoPbClxCRNuac1Du01r9gvNOT+pMYtJDapfB1eoGN1YlJ1BixLyL9WVENRx5RXgNLdfYdx/CuswlGhMw==",
+      "dev": true,
+      "requires": {
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "get-tsconfig": "^4.4.0"
+      }
+    },
+    "@esbuild/android-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-loong64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-mips64el": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ppc64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-riscv64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-s390x": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/netbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/openbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/sunos-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "dev": true,
+      "optional": true
+    },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -9651,29 +10300,41 @@
       "integrity": "sha512-C4JWpgbNik3V99bfGfDell5cH3JULD67eEq9CeXl4rYgsvanF8hhuY84ZYvndPhimt9qjA9/Z8uExKGoiv1zVw=="
     },
     "@matrixai/quic": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic/-/quic-0.0.12.tgz",
-      "integrity": "sha512-aEh21BIgBGqI9IVVAzJF5h/Wu35jmTU35pKLsCJq38wv+1uEbjvWQw3O6oykahHD/2TXwy9ki367lGqOz4ejnw==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic/-/quic-0.0.14.tgz",
+      "integrity": "sha512-FINNs92u0qKXHRmBbUePODEx67IAzVr0XgmMARLGcyMRC3rAuQN0L0fsXJTxokcUqO1aaIYurGhzY4kVwtHW8Q==",
       "requires": {
-        "@matrixai/async-cancellable": "^1.1.0",
+        "@matrixai/async-cancellable": "^1.1.1",
         "@matrixai/async-init": "^1.8.4",
         "@matrixai/async-locks": "^4.0.0",
-        "@matrixai/contexts": "^1.0.0",
+        "@matrixai/contexts": "^1.1.0",
         "@matrixai/errors": "^1.1.7",
         "@matrixai/logger": "^3.1.0",
-        "@matrixai/quic-darwin-arm64": "0.0.12",
-        "@matrixai/quic-darwin-x64": "0.0.12",
-        "@matrixai/quic-linux-x64": "0.0.12",
-        "@matrixai/quic-win32-x64": "0.0.12",
+        "@matrixai/quic-darwin-arm64": "0.0.14",
+        "@matrixai/quic-darwin-x64": "0.0.14",
+        "@matrixai/quic-linux-x64": "0.0.14",
+        "@matrixai/quic-win32-x64": "0.0.14",
         "@matrixai/resources": "^1.1.5",
         "@matrixai/timer": "^1.1.1",
         "ip-num": "^1.5.0"
       }
     },
+    "@matrixai/quic-darwin-arm64": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-arm64/-/quic-darwin-arm64-0.0.14.tgz",
+      "integrity": "sha512-cdC6m02aaqKZi0dOulLhTFYNUALqnptsHzgFCwOU2uwiEbBghIkC/gjrPMpj4KmReb55ZZ5z2cap8KrQCcD0Cw==",
+      "optional": true
+    },
+    "@matrixai/quic-darwin-x64": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-x64/-/quic-darwin-x64-0.0.14.tgz",
+      "integrity": "sha512-zvkGeBGFgOKSXnHFcqZyEqmam6ZhvjKXi5oTp5nzYqGw2lf6KorruEmdQoi414fOZwB+uEvTZuH15rCapvZO2w==",
+      "optional": true
+    },
     "@matrixai/quic-linux-x64": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-linux-x64/-/quic-linux-x64-0.0.12.tgz",
-      "integrity": "sha512-WVS0j0D0UJPGe4q4gVHCppoJ5I6BN4oBTsKKMxMz92g7P9kzx/0JBaEVhHdIJTrxlGDzlKAt9RtZe5hvq/UtpA==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-linux-x64/-/quic-linux-x64-0.0.14.tgz",
+      "integrity": "sha512-t6kCv7Cg9ef6rVMWyH4/mkcRTsxgusXSO+ivlysCOiTK6R+LasTLelzjnWvUvJXfCgY9cJHn7JsZuQsdf/SB0g==",
       "optional": true
     },
     "@matrixai/resources": {
@@ -11197,6 +11858,36 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "esbuild": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "dev": true,
+      "requires": {
+        "@esbuild/android-arm": "0.17.19",
+        "@esbuild/android-arm64": "0.17.19",
+        "@esbuild/android-x64": "0.17.19",
+        "@esbuild/darwin-arm64": "0.17.19",
+        "@esbuild/darwin-x64": "0.17.19",
+        "@esbuild/freebsd-arm64": "0.17.19",
+        "@esbuild/freebsd-x64": "0.17.19",
+        "@esbuild/linux-arm": "0.17.19",
+        "@esbuild/linux-arm64": "0.17.19",
+        "@esbuild/linux-ia32": "0.17.19",
+        "@esbuild/linux-loong64": "0.17.19",
+        "@esbuild/linux-mips64el": "0.17.19",
+        "@esbuild/linux-ppc64": "0.17.19",
+        "@esbuild/linux-riscv64": "0.17.19",
+        "@esbuild/linux-s390x": "0.17.19",
+        "@esbuild/linux-x64": "0.17.19",
+        "@esbuild/netbsd-x64": "0.17.19",
+        "@esbuild/openbsd-x64": "0.17.19",
+        "@esbuild/sunos-x64": "0.17.19",
+        "@esbuild/win32-arm64": "0.17.19",
+        "@esbuild/win32-ia32": "0.17.19",
+        "@esbuild/win32-x64": "0.17.19"
+      }
+    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -11747,6 +12438,15 @@
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
+      }
+    },
+    "get-tsconfig": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.0.tgz",
+      "integrity": "sha512-pmjiZ7xtB8URYm74PlGJozDNyhvsVLUcpBa8DZBG3bWHwaHa9bPiRpiSfovw+fjhwONSCWKRyk+JQHEGZmMrzw==",
+      "dev": true,
+      "requires": {
+        "resolve-pkg-maps": "^1.0.0"
       }
     },
     "github-from-package": {
@@ -13743,9 +14443,9 @@
       }
     },
     "polykey": {
-      "version": "1.1.5-alpha.0",
-      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.1.5-alpha.0.tgz",
-      "integrity": "sha512-jVNKcxgjYpjVpuBBOJ42/k3f4gW/tsJvMA/h+NAIp0Swt1nGSPgAy58lrIDFLd5t+frWmLrb9qEyutiR++cESw==",
+      "version": "1.1.5-feature-agent-migration-stage2.0",
+      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.1.5-feature-agent-migration-stage2.0.tgz",
+      "integrity": "sha512-t95OB8FI5zMJlXqn5q6FNgnJLlJ0VXpucf6NSQXkUyaKdw81XszQaDhs2mZIie7MBTlhg6kmmJohJL1cXadn1g==",
       "requires": {
         "@matrixai/async-cancellable": "^1.1.1",
         "@matrixai/async-init": "^1.8.4",
@@ -13755,7 +14455,7 @@
         "@matrixai/errors": "^1.1.7",
         "@matrixai/id": "^3.3.6",
         "@matrixai/logger": "^3.1.0",
-        "@matrixai/quic": "^0.0.13",
+        "@matrixai/quic": "^0.0.14",
         "@matrixai/resources": "^1.1.5",
         "@matrixai/timer": "^1.1.1",
         "@matrixai/workers": "^1.3.7",
@@ -13770,7 +14470,6 @@
         "ajv": "^7.0.4",
         "canonicalize": "^1.0.5",
         "cheerio": "^1.0.0-rc.5",
-        "commander": "^8.3.0",
         "cross-fetch": "^3.0.6",
         "cross-spawn": "^7.0.3",
         "encryptedfs": "^3.5.6",
@@ -13787,37 +14486,9 @@
         "resource-counter": "^1.2.4",
         "sodium-native": "^3.4.1",
         "threads": "^1.6.5",
-        "tslib": "^2.4.0",
-        "tsyringe": "^4.7.0",
         "ws": "^8.12.0"
       },
       "dependencies": {
-        "@matrixai/quic": {
-          "version": "0.0.13",
-          "resolved": "https://registry.npmjs.org/@matrixai/quic/-/quic-0.0.13.tgz",
-          "integrity": "sha512-tvlA0m2fUIchyEZxzkBbvYNXYf21u0gR4Lv2BaYZYmGa1Fr2VH07MCZu9Ka8DpAEOXKEU94yqhNSEKCCJ83LJA==",
-          "requires": {
-            "@matrixai/async-cancellable": "^1.1.0",
-            "@matrixai/async-init": "^1.8.4",
-            "@matrixai/async-locks": "^4.0.0",
-            "@matrixai/contexts": "^1.0.0",
-            "@matrixai/errors": "^1.1.7",
-            "@matrixai/logger": "^3.1.0",
-            "@matrixai/quic-darwin-arm64": "0.0.13",
-            "@matrixai/quic-darwin-x64": "0.0.13",
-            "@matrixai/quic-linux-x64": "0.0.13",
-            "@matrixai/quic-win32-x64": "0.0.13",
-            "@matrixai/resources": "^1.1.5",
-            "@matrixai/timer": "^1.1.1",
-            "ip-num": "^1.5.0"
-          }
-        },
-        "@matrixai/quic-linux-x64": {
-          "version": "0.0.13",
-          "resolved": "https://registry.npmjs.org/@matrixai/quic-linux-x64/-/quic-linux-x64-0.0.13.tgz",
-          "integrity": "sha512-ExOhO9YjiCNV6OrRMF2+CVQdPANa2zSqlMzCUaLC5whAsll50M08LpoV4J/HnmpTWPcfohr+G28bFWVsnb8/wA==",
-          "optional": true
-        },
         "ajv": {
           "version": "7.2.4",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
@@ -14101,6 +14772,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true
     },
     "resolve.exports": {
@@ -14691,6 +15368,18 @@
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
         }
+      }
+    },
+    "tsx": {
+      "version": "3.12.7",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.12.7.tgz",
+      "integrity": "sha512-C2Ip+jPmqKd1GWVQDvz/Eyc6QJbGfE7NrR3fx5BpEHMZsEHoIxHL1j+lKdGobr8ovEyqeNkPLSKp6SCSOt7gmw==",
+      "dev": true,
+      "requires": {
+        "@esbuild-kit/cjs-loader": "^2.4.2",
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "@esbuild-kit/esm-loader": "^2.5.5",
+        "fsevents": "~2.3.2"
       }
     },
     "tsyringe": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@matrixai/errors": "^1.1.7",
         "@matrixai/logger": "^3.1.0",
         "commander": "^8.3.0",
-        "polykey": "^1.1.5-alpha.0",
+        "polykey": "^1.1.5-feature-agent-migration-stage2.0",
         "threads": "^1.6.5"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     },
     {
       "name": "Emma Casolin"
+    },
+    {
+      "name": "Amy Yan"
     }
   ],
   "description": "Polykey CLI",

--- a/package.json
+++ b/package.json
@@ -84,9 +84,7 @@
   },
   "dependencies": {
     "@matrixai/errors": "^1.1.7",
-    "@matrixai/id": "^3.3.6",
     "@matrixai/logger": "^3.1.0",
-    "@matrixai/quic": "^0.0.12",
     "commander": "^8.3.0",
     "polykey": "^1.1.5-alpha.0",
     "threads": "^1.6.5"

--- a/package.json
+++ b/package.json
@@ -37,10 +37,17 @@
   ],
   "description": "Polykey CLI",
   "keywords": [
+    "polykey",
+    "polykey-cli",
     "secrets",
-    "password"
+    "secrets-management",
+    "password",
+    "password-management",
+    "key",
+    "key-management",
+    "zero-trust"
   ],
-  "license": "Apache-2.0",
+  "license": "GPL-3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/MatrixAI/Polykey-CLI.git"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "type": "git",
     "url": "https://github.com/MatrixAI/Polykey-CLI.git"
   },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "bin": {
     "polykey": "dist/polykey.js",
     "pk": "dist/polykey.js"
@@ -71,12 +73,14 @@
     "prepare": "tsc -p ./tsconfig.build.json",
     "build": "shx rm -rf ./dist && tsc -p ./tsconfig.build.json",
     "postversion": "npm install --package-lock-only --ignore-scripts --silent",
+    "tsx": "tsx",
     "ts-node": "ts-node",
     "test": "jest",
-    "lint": "eslint '{src,tests,scripts}/**/*.{js,ts}'",
-    "lintfix": "eslint '{src,tests,scripts}/**/*.{js,ts}' --fix",
+    "lint": "eslint '{src,tests,scripts,benches}/**/*.{js,mjs,ts,mts,jsx,tsx}'",
+    "lintfix": "eslint '{src,tests,scripts,benches}/**/*.{js,mjs,ts,mts,jsx,tsx}' --fix",
     "lint-shell": "find ./src ./tests ./scripts -type f -regextype posix-extended -regex '.*\\.(sh)' -exec shellcheck {} +",
     "docs": "shx rm -rf ./docs && typedoc --gitRevision master --tsconfig ./tsconfig.build.json --out ./docs src",
+    "bench": "tsc -p ./tsconfig.build.json && shx rm -rf ./benches/results && tsx ./benches/index.ts",
     "pkg": "node ./scripts/pkg.js",
     "polykey": "ts-node src/polykey.ts",
     "start": "ts-node src/polykey.ts -- agent start --verbose",
@@ -113,6 +117,7 @@
     "pkg": "^5.8.1",
     "prettier": "^2.6.2",
     "shx": "^0.3.4",
+    "tsx": "^3.12.7",
     "ts-jest": "^28.0.5",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@matrixai/errors": "^1.1.7",
     "@matrixai/logger": "^3.1.0",
     "commander": "^8.3.0",
-    "polykey": "^1.1.5-alpha.0",
+    "polykey": "^1.1.5-feature-agent-migration-stage2.0",
     "threads": "^1.6.5"
   },
   "devDependencies": {

--- a/src/CommandPolykey.ts
+++ b/src/CommandPolykey.ts
@@ -8,7 +8,7 @@ import Logger, {
 } from '@matrixai/logger';
 import * as binUtils from './utils';
 import * as binOptions from './utils/options';
-import * as binErrors from './errors';
+import * as errors from './errors';
 
 /**
  * Singleton logger constructed once for all commands
@@ -91,7 +91,7 @@ class CommandPolykey extends commander.Command {
       // If the node path is undefined
       // this means there is an unknown platform
       if (opts.nodePath == null) {
-        throw new binErrors.ErrorCLINodePath();
+        throw new errors.ErrorPolykeyCLINodePath();
       }
       await fn(...args);
     });

--- a/src/agent/CommandLock.ts
+++ b/src/agent/CommandLock.ts
@@ -12,10 +12,7 @@ class CommandLock extends CommandPolykey {
         'polykey/dist/sessions/Session'
       );
       const session = new Session({
-        sessionTokenPath: path.join(
-          options.nodePath,
-          config.paths.tokenBase,
-        ),
+        sessionTokenPath: path.join(options.nodePath, config.paths.tokenBase),
         fs: this.fs,
         logger: this.logger.getChild(Session.name),
       });

--- a/src/agent/CommandLock.ts
+++ b/src/agent/CommandLock.ts
@@ -14,7 +14,7 @@ class CommandLock extends CommandPolykey {
       const session = new Session({
         sessionTokenPath: path.join(
           options.nodePath,
-          config.defaults.tokenBase,
+          config.paths.tokenBase,
         ),
         fs: this.fs,
         logger: this.logger.getChild(Session.name),

--- a/src/agent/CommandLockAll.ts
+++ b/src/agent/CommandLockAll.ts
@@ -40,7 +40,7 @@ class CommandLockAll extends CommandPolykey {
       const session = new Session({
         sessionTokenPath: path.join(
           options.nodePath,
-          config.defaults.tokenBase,
+          config.paths.tokenBase,
         ),
         fs: this.fs,
         logger: this.logger.getChild(Session.name),

--- a/src/agent/CommandLockAll.ts
+++ b/src/agent/CommandLockAll.ts
@@ -38,10 +38,7 @@ class CommandLockAll extends CommandPolykey {
         this.fs,
       );
       const session = new Session({
-        sessionTokenPath: path.join(
-          options.nodePath,
-          config.paths.tokenBase,
-        ),
+        sessionTokenPath: path.join(options.nodePath, config.paths.tokenBase),
         fs: this.fs,
         logger: this.logger.getChild(Session.name),
       });

--- a/src/agent/CommandStart.ts
+++ b/src/agent/CommandStart.ts
@@ -16,7 +16,7 @@ import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
 import * as binProcessors from '../utils/processors';
-import * as binErrors from '../errors';
+import * as errors from '../errors';
 
 class CommandStart extends CommandPolykey {
   constructor(...args: ConstructorParameters<typeof CommandPolykey>) {
@@ -158,7 +158,7 @@ class CommandStart extends CommandPolykey {
             return;
           } else {
             rejectAgentProcessP(
-              new binErrors.ErrorCLIPolykeyAgentProcess(
+              new errors.ErrorPolykeyCLIAgentProcess(
                 'Agent process responded with error',
                 messageOut.error,
               ),
@@ -169,14 +169,14 @@ class CommandStart extends CommandPolykey {
         // Handle error event during abnormal spawning, this is rare
         agentProcess.once('error', (e) => {
           rejectAgentProcessP(
-            new binErrors.ErrorCLIPolykeyAgentProcess(e.message),
+            new errors.ErrorPolykeyCLIAgentProcess(e.message),
           );
         });
         // If the process exits during initial execution of polykey-agent script
         // Then it is an exception, because the agent process is meant to be a long-running daemon
         agentProcess.once('close', (code, signal) => {
           rejectAgentProcessP(
-            new binErrors.ErrorCLIPolykeyAgentProcess(
+            new errors.ErrorPolykeyCLIAgentProcess(
               'Agent process closed during fork',
               {
                 data: {
@@ -195,7 +195,7 @@ class CommandStart extends CommandPolykey {
         agentProcess.send(messageIn, (e) => {
           if (e != null) {
             rejectAgentProcessP(
-              new binErrors.ErrorCLIPolykeyAgentProcess(
+              new errors.ErrorPolykeyCLIAgentProcess(
                 'Failed sending agent process message',
               ),
             );
@@ -218,7 +218,7 @@ class CommandStart extends CommandPolykey {
           });
         } catch (e) {
           if (e instanceof keysErrors.ErrorKeyPairParse) {
-            throw new binErrors.ErrorCLIPasswordWrong();
+            throw new errors.ErrorPolykeyCLIPasswordWrong();
           }
           throw e;
         }

--- a/src/agent/CommandStart.ts
+++ b/src/agent/CommandStart.ts
@@ -41,9 +41,9 @@ class CommandStart extends CommandPolykey {
     this.addOption(binOptions.passwordMemLimit);
     this.action(async (options) => {
       options.clientHost =
-        options.clientHost ?? config.defaults.networkConfig.clientHost;
+        options.clientHost ?? config.defaultsUser.clientServiceHost;
       options.clientPort =
-        options.clientPort ?? config.defaults.networkConfig.clientPort;
+        options.clientPort ?? config.defaultsUser.clientServicePort;
       const { default: PolykeyAgent } = await import(
         'polykey/dist/PolykeyAgent'
       );
@@ -228,8 +228,8 @@ class CommandStart extends CommandPolykey {
           nodeId: nodesUtils.encodeNodeId(pkAgent.keyRing.getNodeId()),
           clientHost: pkAgent.webSocketServerClient.getHost(),
           clientPort: pkAgent.webSocketServerClient.getPort(),
-          agentHost: pkAgent.quicSocket.host,
-          agentPort: pkAgent.quicSocket.port,
+          agentHost: pkAgent.nodeConnectionManager.host,
+          agentPort: pkAgent.nodeConnectionManager.port,
         };
       }
       process.stdout.write(

--- a/src/agent/CommandStart.ts
+++ b/src/agent/CommandStart.ts
@@ -228,8 +228,8 @@ class CommandStart extends CommandPolykey {
           nodeId: nodesUtils.encodeNodeId(pkAgent.keyRing.getNodeId()),
           clientHost: pkAgent.webSocketServerClient.getHost(),
           clientPort: pkAgent.webSocketServerClient.getPort(),
-          agentHost: pkAgent.quicServerAgent.host,
-          agentPort: pkAgent.quicServerAgent.port,
+          agentHost: pkAgent.quicSocket.host,
+          agentPort: pkAgent.quicSocket.port,
         };
       }
       process.stdout.write(

--- a/src/agent/CommandStop.ts
+++ b/src/agent/CommandStop.ts
@@ -4,7 +4,7 @@ import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
 import * as binProcessors from '../utils/processors';
-import * as binErrors from '../errors';
+import * as errors from '../errors';
 
 class CommandStop extends CommandPolykey {
   constructor(...args: ConstructorParameters<typeof CommandPolykey>) {
@@ -37,7 +37,7 @@ class CommandStop extends CommandPolykey {
         this.logger.info('Agent is already stopping');
         return;
       } else if (statusInfo?.status === 'STARTING') {
-        throw new binErrors.ErrorCLIPolykeyAgentStatus('agent is starting');
+        throw new errors.ErrorPolykeyCLIAgentStatus('agent is starting');
       }
       const auth = await binProcessors.processAuthentication(
         options.passwordFile,

--- a/src/bootstrap/CommandBootstrap.ts
+++ b/src/bootstrap/CommandBootstrap.ts
@@ -26,14 +26,16 @@ class CommandBootstrap extends CommandPolykey {
       );
       const recoveryCodeOut = await bootstrapUtils.bootstrapState({
         password,
-        nodePath: options.nodePath,
-        keyRingConfig: {
-          recoveryCode: recoveryCodeIn,
-          privateKeyPath: options.privateKeyFile,
-          passwordOpsLimit:
-            keysUtils.passwordOpsLimits[options.passwordOpsLimit],
-          passwordMemLimit:
-            keysUtils.passwordMemLimits[options.passwordMemLimit],
+        options: {
+          nodePath: options.nodePath,
+          keys: {
+            recoveryCode: recoveryCodeIn,
+            privateKeyPath: options.privateKeyFile,
+            passwordOpsLimit:
+              keysUtils.passwordOpsLimits[options.passwordOpsLimit],
+            passwordMemLimit:
+              keysUtils.passwordMemLimits[options.passwordMemLimit],
+          },
         },
         fresh: options.fresh,
         fs: this.fs,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,18 @@
+export { default as CommandPolykey } from './CommandPolykey';
+export { default as polykey } from './polykey';
+export { default as polykeyAgent } from './polykey-agent';
+export * as utils from './utils';
+export * as errors from './errors';
+export * from './types';
+
+// Subdomains for Polykey-CLI
+// Users should prefer importing them directly to avoid importing the entire
+// kitchen sink here
+
+export * as agent from './agent';
+export * as identities from './identities';
+export * as keys from './keys';
+export * as nodes from './nodes';
+export * as notifications from './notifications';
+export * as secrets from './secrets';
+export * as vaults from './vaults';

--- a/src/keys/CommandDecrypt.ts
+++ b/src/keys/CommandDecrypt.ts
@@ -1,6 +1,6 @@
 import type PolykeyClient from 'polykey/dist/PolykeyClient';
 import type WebSocketClient from 'polykey/dist/websockets/WebSocketClient';
-import * as binErrors from '../errors';
+import * as errors from '../errors';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
@@ -61,7 +61,7 @@ class CommandDecrypt extends CommandPolykey {
             encoding: 'binary',
           });
         } catch (e) {
-          throw new binErrors.ErrorCLIFileRead(e.message, {
+          throw new errors.ErrorPolykeyCLIFileRead(e.message, {
             data: {
               errno: e.errno,
               syscall: e.syscall,

--- a/src/keys/CommandEncrypt.ts
+++ b/src/keys/CommandEncrypt.ts
@@ -1,7 +1,7 @@
 import type PolykeyClient from 'polykey/dist/PolykeyClient';
 import type WebSocketClient from 'polykey/dist/websockets/WebSocketClient';
 import type { PublicKeyJWK } from 'polykey/dist/keys/types';
-import * as binErrors from '../errors';
+import * as errors from '../errors';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
@@ -65,7 +65,7 @@ class CommandEncypt extends CommandPolykey {
             encoding: 'binary',
           });
         } catch (e) {
-          throw new binErrors.ErrorCLIFileRead(e.message, {
+          throw new errors.ErrorPolykeyCLIFileRead(e.message, {
             data: {
               errno: e.errno,
               syscall: e.syscall,
@@ -91,7 +91,7 @@ class CommandEncypt extends CommandPolykey {
             // Checking if the JWK is valid
             keysUtils.publicKeyFromJWK(publicJWK);
           } catch (e) {
-            throw new binErrors.ErrorCLIPublicJWKFileRead(
+            throw new errors.ErrorPolykeyCLIPublicJWKFileRead(
               'Failed to parse JWK file',
               { cause: e },
             );

--- a/src/keys/CommandSign.ts
+++ b/src/keys/CommandSign.ts
@@ -1,6 +1,6 @@
 import type PolykeyClient from 'polykey/dist/PolykeyClient';
 import type WebSocketClient from 'polykey/dist/websockets/WebSocketClient';
-import * as binErrors from '../errors';
+import * as errors from '../errors';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
@@ -61,7 +61,7 @@ class CommandSign extends CommandPolykey {
             encoding: 'binary',
           });
         } catch (e) {
-          throw new binErrors.ErrorCLIFileRead(e.message, {
+          throw new errors.ErrorPolykeyCLIFileRead(e.message, {
             data: {
               errno: e.errno,
               syscall: e.syscall,

--- a/src/keys/CommandVerify.ts
+++ b/src/keys/CommandVerify.ts
@@ -1,7 +1,7 @@
 import type PolykeyClient from 'polykey/dist/PolykeyClient';
 import type WebSocketClient from 'polykey/dist/websockets/WebSocketClient';
 import type { PublicKeyJWK } from 'polykey/dist/keys/types';
-import * as binErrors from '../errors';
+import * as errors from '../errors';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
@@ -73,7 +73,7 @@ class CommandVerify extends CommandPolykey {
             encoding: 'binary',
           });
         } catch (e) {
-          throw new binErrors.ErrorCLIFileRead(e.message, {
+          throw new errors.ErrorPolykeyCLIFileRead(e.message, {
             data: {
               errno: e.errno,
               syscall: e.syscall,
@@ -99,7 +99,7 @@ class CommandVerify extends CommandPolykey {
             // Checking if the JWK is valid
             keysUtils.publicKeyFromJWK(publicJWK);
           } catch (e) {
-            throw new binErrors.ErrorCLIPublicJWKFileRead(
+            throw new errors.ErrorPolykeyCLIPublicJWKFileRead(
               'Failed to parse JWK file',
               { cause: e },
             );

--- a/src/nodes/CommandFind.ts
+++ b/src/nodes/CommandFind.ts
@@ -7,7 +7,7 @@ import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
 import * as binProcessors from '../utils/processors';
 import * as binParsers from '../utils/parsers';
-import * as binErrors from '../errors';
+import * as errors from '../errors';
 
 class CommandFind extends CommandPolykey {
   constructor(...args: ConstructorParameters<typeof CommandPolykey>) {
@@ -105,7 +105,7 @@ class CommandFind extends CommandPolykey {
         );
         // Like ping it should error when failing to find node for automation reasons.
         if (!result.success) {
-          throw new binErrors.ErrorCLINodeFindFailed(result.message);
+          throw new errors.ErrorPolykeyCLINodeFindFailed(result.message);
         }
       } finally {
         if (pkClient! != null) await pkClient.stop();

--- a/src/nodes/CommandPing.ts
+++ b/src/nodes/CommandPing.ts
@@ -67,7 +67,9 @@ class CommandPing extends CommandPolykey {
         const status = { success: false, message: '' };
         status.success = statusMessage ? statusMessage.success : false;
         if (!status.success && !error) {
-          error = new errors.ErrorPolykeyCLINodePingFailed('No response received');
+          error = new errors.ErrorPolykeyCLINodePingFailed(
+            'No response received',
+          );
         }
         if (status.success) status.message = 'Node is Active.';
         else status.message = error.message;

--- a/src/nodes/CommandPing.ts
+++ b/src/nodes/CommandPing.ts
@@ -6,7 +6,7 @@ import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
 import * as binProcessors from '../utils/processors';
 import * as binParsers from '../utils/parsers';
-import * as binErrors from '../errors';
+import * as errors from '../errors';
 
 class CommandPing extends CommandPolykey {
   constructor(...args: ConstructorParameters<typeof CommandPolykey>) {
@@ -67,7 +67,7 @@ class CommandPing extends CommandPolykey {
         const status = { success: false, message: '' };
         status.success = statusMessage ? statusMessage.success : false;
         if (!status.success && !error) {
-          error = new binErrors.ErrorCLINodePingFailed('No response received');
+          error = new errors.ErrorPolykeyCLINodePingFailed('No response received');
         }
         if (status.success) status.message = 'Node is Active.';
         else status.message = error.message;

--- a/src/polykey-agent.ts
+++ b/src/polykey-agent.ts
@@ -113,8 +113,8 @@ async function main(_argv = process.argv): Promise<number> {
     nodeId: nodesUtils.encodeNodeId(pkAgent.keyRing.getNodeId()),
     clientHost: pkAgent.webSocketServerClient.getHost(),
     clientPort: pkAgent.webSocketServerClient.getPort(),
-    agentHost: pkAgent.quicSocket.host,
-    agentPort: pkAgent.quicSocket.port,
+    agentHost: pkAgent.nodeConnectionManager.host,
+    agentPort: pkAgent.nodeConnectionManager.port,
   };
   try {
     await processSend(messageOut);

--- a/src/polykey-agent.ts
+++ b/src/polykey-agent.ts
@@ -113,8 +113,8 @@ async function main(_argv = process.argv): Promise<number> {
     nodeId: nodesUtils.encodeNodeId(pkAgent.keyRing.getNodeId()),
     clientHost: pkAgent.webSocketServerClient.getHost(),
     clientPort: pkAgent.webSocketServerClient.getPort(),
-    agentHost: pkAgent.quicServerAgent.host,
-    agentPort: pkAgent.quicServerAgent.port,
+    agentHost: pkAgent.quicSocket.host,
+    agentPort: pkAgent.quicSocket.port,
   };
   try {
     await processSend(messageOut);

--- a/src/secrets/CommandCreate.ts
+++ b/src/secrets/CommandCreate.ts
@@ -1,6 +1,6 @@
 import type PolykeyClient from 'polykey/dist/PolykeyClient';
 import type WebSocketClient from 'polykey/dist/websockets/WebSocketClient';
-import * as binErrors from '../errors';
+import * as errors from '../errors';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
@@ -65,7 +65,7 @@ class CommandCreate extends CommandPolykey {
         try {
           content = await this.fs.promises.readFile(directoryPath);
         } catch (e) {
-          throw new binErrors.ErrorCLIFileRead(e.message, {
+          throw new errors.ErrorPolykeyCLIFileRead(e.message, {
             data: {
               errno: e.errno,
               syscall: e.syscall,

--- a/src/secrets/CommandEdit.ts
+++ b/src/secrets/CommandEdit.ts
@@ -1,6 +1,6 @@
 import type PolykeyClient from 'polykey/dist/PolykeyClient';
 import type WebSocketClient from 'polykey/dist/websockets/WebSocketClient';
-import * as binErrors from '../errors';
+import * as errors from '../errors';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
@@ -79,7 +79,7 @@ class CommandEdit extends CommandPolykey {
         try {
           content = await this.fs.promises.readFile(tmpFile);
         } catch (e) {
-          throw new binErrors.ErrorCLIFileRead(e.message, {
+          throw new errors.ErrorPolykeyCLIFileRead(e.message, {
             data: {
               errno: e.errno,
               syscall: e.syscall,

--- a/src/secrets/CommandUpdate.ts
+++ b/src/secrets/CommandUpdate.ts
@@ -1,6 +1,6 @@
 import type PolykeyClient from 'polykey/dist/PolykeyClient';
 import type WebSocketClient from 'polykey/dist/websockets/WebSocketClient';
-import * as binErrors from '../errors';
+import * as errors from '../errors';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
@@ -65,7 +65,7 @@ class CommandUpdate extends CommandPolykey {
         try {
           content = await this.fs.promises.readFile(directoryPath);
         } catch (e) {
-          throw new binErrors.ErrorCLIFileRead(e.message, {
+          throw new errors.ErrorPolykeyCLIFileRead(e.message, {
             data: {
               errno: e.errno,
               syscall: e.syscall,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,14 +1,9 @@
 import type { LogLevel } from '@matrixai/logger';
-import type { POJO } from 'polykey/dist/types';
+import type { PolykeyAgentOptions } from 'polykey/dist/PolykeyAgent';
+import type { POJO, DeepPartial } from 'polykey/dist/types';
 import type { RecoveryCode } from 'polykey/dist/keys/types';
-import type { Host, Port } from 'polykey/dist/network/types';
 import type { StatusLive } from 'polykey/dist/status/types';
 import type { NodeIdEncoded } from 'polykey/dist/ids/types';
-import type { PrivateKey } from 'polykey/dist/keys/types';
-import type {
-  PasswordOpsLimit,
-  PasswordMemLimit,
-} from 'polykey/dist/keys/types';
 
 type AgentStatusLiveData = Omit<StatusLive['data'], 'nodeId'> & {
   nodeId: NodeIdEncoded;
@@ -26,41 +21,7 @@ type AgentChildProcessInput = {
   workers?: number;
   agentConfig: {
     password: string;
-    nodePath?: string;
-    keyRingConfig?: {
-      recoveryCode?: RecoveryCode;
-      privateKey?: PrivateKey;
-      privateKeyPath?: string;
-      passwordOpsLimit?: PasswordOpsLimit;
-      passwordMemLimit?: PasswordMemLimit;
-      strictMemoryLock?: boolean;
-    };
-    certManagerConfig?: {
-      certDuration?: number;
-    };
-    nodeConnectionManagerConfig?: {
-      connConnectTime?: number;
-      connTimeoutTime?: number;
-      initialClosestNodes?: number;
-      pingTimeout?: number;
-      holePunchTimeout?: number;
-      holePunchInitialInterval?: number;
-    };
-    networkConfig?: {
-      agentHost?: Host;
-      agentPort?: Port;
-      clientHost?: Host;
-      clientPort?: Port;
-      ipv6Only?: boolean;
-      agentKeepAliveIntervalTime?: number;
-      agentMaxIdleTimeout?: number;
-      clientMaxIdleTimeoutTime?: number;
-      clientPingIntervalTime?: number;
-      clientPingTimeoutTime?: number;
-      clientParserBufferByteLimit?: number;
-      clientHandlerTimeoutTime?: number;
-      clientHandlerTimeoutGraceTime?: number;
-    };
+    options: DeepPartial<PolykeyAgentOptions>;
     fresh?: boolean;
   };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,24 +9,10 @@ import type {
   PasswordOpsLimit,
   PasswordMemLimit,
 } from 'polykey/dist/keys/types';
-import type { QUICConfig } from '@matrixai/quic';
 
 type AgentStatusLiveData = Omit<StatusLive['data'], 'nodeId'> & {
   nodeId: NodeIdEncoded;
 };
-
-// TODO: fix this... We don't need a dependecy on `@matrixai/quic
-type PolykeyQUICConfig = {
-  // Optionals
-  keepAliveIntervalTime?: number;
-  maxIdleTimeout?: number;
-  // Disabled, set internally
-  ca?: never;
-  key?: never;
-  cert?: never;
-  verifyPeer?: never;
-  verifyAllowFail?: never;
-} & Partial<QUICConfig>;
 
 /**
  * PolykeyAgent Starting Input when Backgrounded
@@ -61,25 +47,20 @@ type AgentChildProcessInput = {
       holePunchInitialInterval?: number;
     };
     networkConfig?: {
-      // Agent QUICSocket config
       agentHost?: Host;
       agentPort?: Port;
-      ipv6Only?: boolean;
-      // RPCServer for client service
       clientHost?: Host;
       clientPort?: Port;
-      // Websocket server config
-      maxReadableStreamBytes?: number;
-      connectionIdleTimeoutTime?: number;
-      pingIntervalTime?: number;
-      pingTimeoutTime?: number;
-      // RPC config
+      ipv6Only?: boolean;
+      agentKeepAliveIntervalTime?: number;
+      agentMaxIdleTimeout?: number;
+      clientMaxIdleTimeoutTime?: number;
+      clientPingIntervalTime?: number;
+      clientPingTimeoutTime?: number;
       clientParserBufferByteLimit?: number;
-      handlerTimeoutTime?: number;
-      handlerTimeoutGraceTime?: number;
+      clientHandlerTimeoutTime?: number;
+      clientHandlerTimeoutGraceTime?: number;
     };
-    quicServerConfig?: PolykeyQUICConfig;
-    quicClientConfig?: PolykeyQUICConfig;
     fresh?: boolean;
   };
 };

--- a/src/utils/ExitHandlers.ts
+++ b/src/utils/ExitHandlers.ts
@@ -1,7 +1,7 @@
 import process from 'process';
 import ErrorPolykey from 'polykey/dist/ErrorPolykey';
 import * as binUtils from './utils';
-import * as binErrors from '../errors';
+import * as errors from '../errors';
 
 class ExitHandlers {
   /**
@@ -64,7 +64,7 @@ class ExitHandlers {
       return;
     }
     this._exiting = true;
-    const error = new binErrors.ErrorBinUnhandledRejection(undefined, {
+    const error = new errors.ErrorPolykeyCLIUnhandledRejection(undefined, {
       cause: e,
     });
     process.stderr.write(
@@ -88,7 +88,7 @@ class ExitHandlers {
       return;
     }
     this._exiting = true;
-    const error = new binErrors.ErrorBinUncaughtException(undefined, {
+    const error = new errors.ErrorPolykeyCLIUncaughtException(undefined, {
       cause: e,
     });
     process.stderr.write(
@@ -104,7 +104,7 @@ class ExitHandlers {
 
   protected deadlockHandler = async () => {
     if (process.exitCode == null) {
-      const e = new binErrors.ErrorBinAsynchronousDeadlock<undefined>();
+      const e = new errors.ErrorPolykeyCLIAsynchronousDeadlock<undefined>();
       process.stderr.write(
         binUtils.outputFormatter({
           type: this._errFormat,

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -21,7 +21,7 @@ const nodePath = new commander.Option(
   'Path to Node State',
 )
   .env('PK_NODE_PATH')
-  .default(config.defaults.nodePath);
+  .default(config.defaultsUser.nodePath);
 
 /**
  * Formatting choice of human, json, defaults to human
@@ -76,19 +76,19 @@ const clientPort = new commander.Option(
 const agentHost = new commander.Option('-ah, --agent-host <host>', 'Agent host')
   .env('PK_AGENT_HOST')
   .argParser(binParsers.parseHost)
-  .default(config.defaults.networkConfig.agentHost);
+  .default(config.defaultsUser.agentServiceHost);
 
 const agentPort = new commander.Option('-ap, --agent-port <port>', 'Agent Port')
   .env('PK_AGENT_PORT')
   .argParser(binParsers.parsePort)
-  .default(config.defaults.networkConfig.agentPort);
+  .default(config.defaultsUser.agentServicePort);
 
 const connConnectTime = new commander.Option(
   '--connection-timeout <ms>',
   'Timeout value for connection establishment between nodes',
 )
   .argParser(binParsers.parseInteger)
-  .default(config.defaults.nodeConnectionManagerConfig.connectionConnectTime);
+  .default(config.defaultsSystem.nodesConnectionConnectTimeoutTime);
 
 const passwordFile = new commander.Option(
   '-pf, --password-file <path>',
@@ -134,7 +134,7 @@ const network = new commander.Option(
 )
   .argParser(binParsers.parseNetwork)
   .env('PK_NETWORK')
-  .default(config.defaults.network.mainnet);
+  .default(config.network.mainnet);
 
 const workers = new commander.Option(
   '-w --workers <count>',

--- a/src/utils/processors.ts
+++ b/src/utils/processors.ts
@@ -218,8 +218,8 @@ async function processClientOptions(
       clientPort,
     };
   } else if (nodeId == null && clientHost == null && clientPort == null) {
-    const statusPath = path.join(nodePath, config.defaults.statusBase);
-    const statusLockPath = path.join(nodePath, config.defaults.statusLockBase);
+    const statusPath = path.join(nodePath, config.paths.statusBase);
+    const statusLockPath = path.join(nodePath, config.paths.statusLockBase);
     const status = new Status({
       statusPath,
       statusLockPath,
@@ -301,8 +301,8 @@ async function processClientStatus(
       clientPort,
     };
   } else if (nodeId == null && clientHost == null && clientPort == null) {
-    const statusPath = path.join(nodePath, config.defaults.statusBase);
-    const statusLockPath = path.join(nodePath, config.defaults.statusLockBase);
+    const statusPath = path.join(nodePath, config.paths.statusBase);
+    const statusLockPath = path.join(nodePath, config.paths.statusLockBase);
     const status = new Status({
       statusPath,
       statusLockPath,

--- a/src/utils/processors.ts
+++ b/src/utils/processors.ts
@@ -15,7 +15,7 @@ import Status from 'polykey/dist/status/Status';
 import * as clientUtils from 'polykey/dist/client/utils/utils';
 import { arrayZip } from 'polykey/dist/utils';
 import config from 'polykey/dist/config';
-import * as binErrors from '../errors';
+import * as errors from '../errors';
 
 /**
  * Prompts for existing password
@@ -86,7 +86,7 @@ async function processPassword(
     try {
       password = (await fs.promises.readFile(passwordFile, 'utf-8')).trim();
     } catch (e) {
-      throw new binErrors.ErrorCLIPasswordFileRead(e.message, {
+      throw new errors.ErrorPolykeyCLIPasswordFileRead(e.message, {
         data: {
           errno: e.errno,
           syscall: e.syscall,
@@ -101,7 +101,7 @@ async function processPassword(
   } else {
     password = await promptPassword();
     if (password === undefined) {
-      throw new binErrors.ErrorCLIPasswordMissing();
+      throw new errors.ErrorPolykeyCLIPasswordMissing();
     }
   }
   return password;
@@ -131,7 +131,7 @@ async function processNewPassword(
         await fs.promises.readFile(passwordNewFile, 'utf-8')
       ).trim();
     } catch (e) {
-      throw new binErrors.ErrorCLIPasswordFileRead(e.message, {
+      throw new errors.ErrorPolykeyCLIPasswordFileRead(e.message, {
         data: {
           errno: e.errno,
           syscall: e.syscall,
@@ -148,7 +148,7 @@ async function processNewPassword(
   } else {
     passwordNew = await promptNewPassword();
     if (passwordNew === undefined) {
-      throw new binErrors.ErrorCLIPasswordMissing();
+      throw new errors.ErrorPolykeyCLIPasswordMissing();
     }
   }
   return passwordNew;
@@ -172,7 +172,7 @@ async function processRecoveryCode(
         await fs.promises.readFile(recoveryCodeFile, 'utf-8')
       ).trim();
     } catch (e) {
-      throw new binErrors.ErrorCLIRecoveryCodeFileRead(e.message, {
+      throw new errors.ErrorPolykeyCLIRecoveryCodeFileRead(e.message, {
         data: {
           errno: e.errno,
           syscall: e.syscall,
@@ -228,7 +228,7 @@ async function processClientOptions(
     });
     const statusInfo = await status.readStatus();
     if (statusInfo === undefined || statusInfo.status !== 'LIVE') {
-      throw new binErrors.ErrorCLIPolykeyAgentStatus('agent is not live');
+      throw new errors.ErrorPolykeyCLIAgentStatus('agent is not live');
     }
     return {
       nodeId: statusInfo.data.nodeId,
@@ -252,7 +252,7 @@ async function processClientOptions(
         }
       })
       .join('; ');
-    throw new binErrors.ErrorCLIClientOptions(errorMsg);
+    throw new errors.ErrorPolykeyCLIClientOptions(errorMsg);
   }
 }
 
@@ -355,7 +355,7 @@ async function processClientStatus(
         }
       })
       .join('; ');
-    throw new binErrors.ErrorCLIClientOptions(errorMsg);
+    throw new errors.ErrorPolykeyCLIClientOptions(errorMsg);
   }
 }
 
@@ -379,7 +379,7 @@ async function processAuthentication(
     try {
       password = (await fs.promises.readFile(passwordFile, 'utf-8')).trim();
     } catch (e) {
-      throw new binErrors.ErrorCLIPasswordFileRead(e.message, {
+      throw new errors.ErrorPolykeyCLIPasswordFileRead(e.message, {
         data: {
           errno: e.errno,
           syscall: e.syscall,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -7,7 +7,7 @@ import * as clientErrors from 'polykey/dist/client/errors';
 import * as utils from 'polykey/dist/utils';
 import * as rpcErrors from 'polykey/dist/rpc/errors';
 import * as binProcessors from './processors';
-import * as binErrors from '../errors';
+import * as errors from '../errors';
 
 /**
  * Convert verbosity to LogLevel
@@ -199,7 +199,7 @@ async function retryAuthentication<T>(
     // Prompt the user for password
     const password = await binProcessors.promptPassword();
     if (password == null) {
-      throw new binErrors.ErrorCLIPasswordMissing();
+      throw new errors.ErrorPolykeyCLIPasswordMissing();
     }
     // Augment existing metadata
     const auth = {

--- a/tests/agent/lock.test.ts
+++ b/tests/agent/lock.test.ts
@@ -41,7 +41,7 @@ describe('lock', () => {
     });
     expect(exitCode).toBe(0);
     const session = await Session.createSession({
-      sessionTokenPath: path.join(agentDir, config.defaults.tokenBase),
+      sessionTokenPath: path.join(agentDir, config.paths.tokenBase),
       fs,
       logger,
     });

--- a/tests/agent/lockall.test.ts
+++ b/tests/agent/lockall.test.ts
@@ -45,7 +45,7 @@ describe('lockall', () => {
     });
     expect(exitCode).toBe(0);
     const session = await Session.createSession({
-      sessionTokenPath: path.join(agentDir, config.defaults.tokenBase),
+      sessionTokenPath: path.join(agentDir, config.paths.tokenBase),
       fs,
       logger,
     });
@@ -93,7 +93,7 @@ describe('lockall', () => {
         command: globalThis.testCmd,
       });
       const session = await Session.createSession({
-        sessionTokenPath: path.join(agentDir, config.defaults.tokenBase),
+        sessionTokenPath: path.join(agentDir, config.paths.tokenBase),
         fs,
         logger,
       });

--- a/tests/agent/start.test.ts
+++ b/tests/agent/start.test.ts
@@ -911,10 +911,7 @@ describe('start', () => {
         const password = 'abc123';
         const nodePath = path.join(dataDir, 'polykey');
         const statusPath = path.join(nodePath, config.paths.statusBase);
-        const statusLockPath = path.join(
-          nodePath,
-          config.paths.statusLockBase,
-        );
+        const statusLockPath = path.join(nodePath, config.paths.statusLockBase);
         const status = new Status({
           statusPath,
           statusLockPath,
@@ -978,10 +975,7 @@ describe('start', () => {
         const password = 'abc123';
         const nodePath = path.join(dataDir, 'polykey');
         const statusPath = path.join(nodePath, config.paths.statusBase);
-        const statusLockPath = path.join(
-          nodePath,
-          config.paths.statusLockBase,
-        );
+        const statusLockPath = path.join(nodePath, config.paths.statusLockBase);
         const status = new Status({
           statusPath,
           statusLockPath,

--- a/tests/agent/start.test.ts
+++ b/tests/agent/start.test.ts
@@ -88,11 +88,11 @@ describe('start', () => {
       ).toBe(true);
       agentProcess.kill('SIGTERM');
       const status = new Status({
-        statusPath: path.join(dataDir, 'polykey', config.defaults.statusBase),
+        statusPath: path.join(dataDir, 'polykey', config.paths.statusBase),
         statusLockPath: path.join(
           dataDir,
           'polykey',
-          config.defaults.statusLockBase,
+          config.paths.statusLockBase,
         ),
         fs,
         logger,
@@ -183,11 +183,11 @@ describe('start', () => {
       );
       expect(polykeyAgentOut).toHaveLength(0);
       const status = new Status({
-        statusPath: path.join(dataDir, 'polykey', config.defaults.statusBase),
+        statusPath: path.join(dataDir, 'polykey', config.paths.statusBase),
         statusLockPath: path.join(
           dataDir,
           'polykey',
-          config.defaults.statusLockBase,
+          config.paths.statusLockBase,
         ),
         fs,
         logger,
@@ -467,11 +467,11 @@ describe('start', () => {
         logger,
       );
       const status = new Status({
-        statusPath: path.join(dataDir, 'polykey', config.defaults.statusBase),
+        statusPath: path.join(dataDir, 'polykey', config.paths.statusBase),
         statusLockPath: path.join(
           dataDir,
           'polykey',
-          config.defaults.statusLockBase,
+          config.paths.statusLockBase,
         ),
         fs,
         logger,
@@ -581,11 +581,11 @@ describe('start', () => {
       await testUtils.processExit(agentProcess2);
       // Check for graceful exit
       const status = new Status({
-        statusPath: path.join(dataDir, 'polykey', config.defaults.statusBase),
+        statusPath: path.join(dataDir, 'polykey', config.paths.statusBase),
         statusLockPath: path.join(
           dataDir,
           'polykey',
-          config.defaults.statusLockBase,
+          config.paths.statusLockBase,
         ),
         fs,
         logger,
@@ -603,11 +603,11 @@ describe('start', () => {
       const password1 = 'abc123';
       const password2 = 'new password';
       const status = new Status({
-        statusPath: path.join(dataDir, 'polykey', config.defaults.statusBase),
+        statusPath: path.join(dataDir, 'polykey', config.paths.statusBase),
         statusLockPath: path.join(
           dataDir,
           'polykey',
-          config.defaults.statusLockBase,
+          config.paths.statusLockBase,
         ),
         fs,
         logger,
@@ -751,11 +751,11 @@ describe('start', () => {
     'start with network configuration',
     async () => {
       const status = new Status({
-        statusPath: path.join(dataDir, 'polykey', config.defaults.statusBase),
+        statusPath: path.join(dataDir, 'polykey', config.paths.statusBase),
         statusLockPath: path.join(
           dataDir,
           'polykey',
-          config.defaults.statusLockBase,
+          config.paths.statusLockBase,
         ),
         fs,
         logger,
@@ -811,11 +811,11 @@ describe('start', () => {
     'start with --private-key-file override',
     async () => {
       const status = new Status({
-        statusPath: path.join(dataDir, 'polykey', config.defaults.statusBase),
+        statusPath: path.join(dataDir, 'polykey', config.paths.statusBase),
         statusLockPath: path.join(
           dataDir,
           'polykey',
-          config.defaults.statusLockBase,
+          config.paths.statusLockBase,
         ),
         fs,
         logger,
@@ -910,10 +910,10 @@ describe('start', () => {
       async () => {
         const password = 'abc123';
         const nodePath = path.join(dataDir, 'polykey');
-        const statusPath = path.join(nodePath, config.defaults.statusBase);
+        const statusPath = path.join(nodePath, config.paths.statusBase);
         const statusLockPath = path.join(
           nodePath,
-          config.defaults.statusLockBase,
+          config.paths.statusLockBase,
         );
         const status = new Status({
           statusPath,
@@ -977,10 +977,10 @@ describe('start', () => {
       async () => {
         const password = 'abc123';
         const nodePath = path.join(dataDir, 'polykey');
-        const statusPath = path.join(nodePath, config.defaults.statusBase);
+        const statusPath = path.join(nodePath, config.paths.statusBase);
         const statusLockPath = path.join(
           nodePath,
-          config.defaults.statusLockBase,
+          config.paths.statusLockBase,
         );
         const status = new Status({
           statusPath,

--- a/tests/agent/status.test.ts
+++ b/tests/agent/status.test.ts
@@ -30,11 +30,11 @@ describe('status', () => {
       // This test must create its own agent process
       const password = 'abc123';
       const status = new Status({
-        statusPath: path.join(dataDir, 'polykey', config.defaults.statusBase),
+        statusPath: path.join(dataDir, 'polykey', config.paths.statusBase),
         statusLockPath: path.join(
           dataDir,
           'polykey',
-          config.defaults.statusLockBase,
+          config.paths.statusLockBase,
         ),
         fs,
         logger,
@@ -154,8 +154,8 @@ describe('status', () => {
       testUtils.isTestPlatformEmpty || testUtils.isTestPlatformDocker,
     )('status on LIVE agent', async () => {
       const status = new Status({
-        statusPath: path.join(agentDir, config.defaults.statusBase),
-        statusLockPath: path.join(agentDir, config.defaults.statusLockBase),
+        statusPath: path.join(agentDir, config.paths.statusBase),
+        statusLockPath: path.join(agentDir, config.paths.statusLockBase),
         fs,
         logger,
       });
@@ -190,8 +190,8 @@ describe('status', () => {
       const passwordPath = path.join(dataDir, 'password');
       await fs.promises.writeFile(passwordPath, agentPassword);
       const status = new Status({
-        statusPath: path.join(agentDir, config.defaults.statusBase),
-        statusLockPath: path.join(agentDir, config.defaults.statusLockBase),
+        statusPath: path.join(agentDir, config.paths.statusBase),
+        statusLockPath: path.join(agentDir, config.paths.statusLockBase),
         fs,
         logger,
       });

--- a/tests/agent/stop.test.ts
+++ b/tests/agent/stop.test.ts
@@ -52,11 +52,11 @@ describe('stop', () => {
         logger,
       );
       const status = new Status({
-        statusPath: path.join(dataDir, 'polykey', config.defaults.statusBase),
+        statusPath: path.join(dataDir, 'polykey', config.paths.statusBase),
         statusLockPath: path.join(
           dataDir,
           'polykey',
-          config.defaults.statusLockBase,
+          config.paths.statusLockBase,
         ),
         fs,
         logger,
@@ -85,11 +85,11 @@ describe('stop', () => {
       const passwordPath = path.join(dataDir, 'password');
       await fs.promises.writeFile(passwordPath, password);
       const status = new Status({
-        statusPath: path.join(dataDir, 'polykey', config.defaults.statusBase),
+        statusPath: path.join(dataDir, 'polykey', config.paths.statusBase),
         statusLockPath: path.join(
           dataDir,
           'polykey',
-          config.defaults.statusLockBase,
+          config.paths.statusLockBase,
         ),
         fs,
         logger,
@@ -183,11 +183,11 @@ describe('stop', () => {
       //  docker may not run this fast enough
       const password = 'abc123';
       const status = new Status({
-        statusPath: path.join(dataDir, 'polykey', config.defaults.statusBase),
+        statusPath: path.join(dataDir, 'polykey', config.paths.statusBase),
         statusLockPath: path.join(
           dataDir,
           'polykey',
-          config.defaults.statusLockBase,
+          config.paths.statusLockBase,
         ),
         fs,
         logger,
@@ -270,11 +270,11 @@ describe('stop', () => {
         logger,
       );
       const status = new Status({
-        statusPath: path.join(dataDir, 'polykey', config.defaults.statusBase),
+        statusPath: path.join(dataDir, 'polykey', config.paths.statusBase),
         statusLockPath: path.join(
           dataDir,
           'polykey',
-          config.defaults.statusLockBase,
+          config.paths.statusLockBase,
         ),
         fs,
         logger,

--- a/tests/agent/stop.test.ts
+++ b/tests/agent/stop.test.ts
@@ -176,7 +176,7 @@ describe('stop', () => {
     },
     globalThis.defaultTimeout * 2,
   );
-  testUtils.testIf(testUtils.isTestPlatformEmpty)(
+  testUtils.testIf(testUtils.isTestPlatformEmpty).only(
     'stopping starting agent results in error',
     async () => {
       // This relies on fast execution of `agent stop` while agent is starting,
@@ -225,7 +225,7 @@ describe('stop', () => {
         },
       );
       testUtils.expectProcessError(exitCode, stderr, [
-        new binErrors.ErrorCLIPolykeyAgentStatus('agent is starting'),
+        new binErrors.ErrorPolykeyCLIAgentStatus('agent is starting'),
       ]);
       await status.waitFor('LIVE');
       await testUtils.pkStdio(['agent', 'stop'], {

--- a/tests/agent/unlock.test.ts
+++ b/tests/agent/unlock.test.ts
@@ -25,7 +25,7 @@ describe('unlock', () => {
   )('unlock acquires session token', async () => {
     // Fresh session, to delete the token
     const session = await Session.createSession({
-      sessionTokenPath: path.join(agentDir, config.defaults.tokenBase),
+      sessionTokenPath: path.join(agentDir, config.paths.tokenBase),
       fs,
       logger,
       fresh: true,

--- a/tests/global.d.ts
+++ b/tests/global.d.ts
@@ -10,7 +10,6 @@ declare var projectDir: string;
 declare var testDir: string;
 declare var dataDir: string;
 declare var defaultTimeout: number;
-declare var polykeyStartupTimeout: number;
 declare var failedConnectionTimeout: number;
 declare var maxTimeout: number;
 declare var testCmd: string | undefined;

--- a/tests/identities/allowDisallowPermissions.test.ts
+++ b/tests/identities/allowDisallowPermissions.test.ts
@@ -74,8 +74,8 @@ describe('allow/disallow/permissions', () => {
       },
     });
     nodeId = node.keyRing.getNodeId();
-    nodeHost = node.quicServerAgent.host as unknown as Host;
-    nodePort = node.quicServerAgent.port as unknown as Port;
+    nodeHost = node.quicSocket.host as unknown as Host;
+    nodePort = node.quicSocket.port as unknown as Port;
     node.identitiesManager.registerProvider(provider);
     await node.identitiesManager.putToken(provider.id, identity, {
       accessToken: 'def456',

--- a/tests/identities/discoverGet.test.ts
+++ b/tests/identities/discoverGet.test.ts
@@ -60,8 +60,8 @@ describe('discover/get', () => {
       },
     });
     nodeAId = nodeA.keyRing.getNodeId();
-    nodeAHost = nodeA.quicServerAgent.host as unknown as Host;
-    nodeAPort = nodeA.quicServerAgent.port as unknown as Port;
+    nodeAHost = nodeA.quicSocket.host as unknown as Host;
+    nodeAPort = nodeA.quicSocket.port as unknown as Port;
     nodeB = await PolykeyAgent.createPolykeyAgent({
       password,
       nodePath: path.join(dataDir, 'nodeB'),

--- a/tests/identities/trustUntrustList.test.ts
+++ b/tests/identities/trustUntrustList.test.ts
@@ -76,8 +76,8 @@ describe('trust/untrust/list', () => {
       },
     });
     nodeId = node.keyRing.getNodeId();
-    nodeHost = node.quicServerAgent.host as unknown as Host;
-    nodePort = node.quicServerAgent.port as unknown as Port;
+    nodeHost = node.quicSocket.host as unknown as Host;
+    nodePort = node.quicSocket.port as unknown as Port;
     node.identitiesManager.registerProvider(provider);
     await node.identitiesManager.putToken(provider.id, identity, {
       accessToken: 'def456',

--- a/tests/nat/DMZ.test.ts
+++ b/tests/nat/DMZ.test.ts
@@ -95,11 +95,11 @@ describe.skip('DMZ', () => {
       expect(signal).toBe('SIGTERM');
       // Check for graceful exit
       const status = new Status({
-        statusPath: path.join(dataDir, 'polykey', config.defaults.statusBase),
+        statusPath: path.join(dataDir, 'polykey', config.paths.statusBase),
         statusLockPath: path.join(
           dataDir,
           'polykey',
-          config.defaults.statusLockBase,
+          config.paths.statusLockBase,
         ),
         fs,
         logger,

--- a/tests/nodes/add.test.ts
+++ b/tests/nodes/add.test.ts
@@ -3,19 +3,19 @@ import type { Host } from 'polykey/dist/network/types';
 import path from 'path';
 import fs from 'fs';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
-import { IdInternal } from '@matrixai/id';
-import { sysexits } from 'polykey/dist/utils';
 import PolykeyAgent from 'polykey/dist/PolykeyAgent';
-import * as nodesUtils from 'polykey/dist/nodes/utils';
 import NodeManager from 'polykey/dist/nodes/NodeManager';
+import * as ids from 'polykey/dist/ids';
+import * as nodesUtils from 'polykey/dist/nodes/utils';
 import * as keysUtils from 'polykey/dist/keys/utils';
+import sysexits from 'polykey/dist/utils/sysexits';
 import * as testUtils from '../utils';
 
 describe('add', () => {
   const logger = new Logger('add test', LogLevel.WARN, [new StreamHandler()]);
   const password = 'helloworld';
-  const validNodeId = testUtils.generateRandomNodeId();
-  const invalidNodeId = IdInternal.fromString<NodeId>('INVALIDID');
+  const nodeIdGenerator = ids.createNodeIdGenerator();
+  const validNodeId = nodeIdGenerator();
   const validHost = '0.0.0.0';
   const invalidHost = 'INVALIDHOST';
   const port = 55555;
@@ -95,7 +95,7 @@ describe('add', () => {
         [
           'nodes',
           'add',
-          nodesUtils.encodeNodeId(invalidNodeId),
+          'INVALIDNODEID',
           validHost,
           `${port}`,
         ],

--- a/tests/nodes/add.test.ts
+++ b/tests/nodes/add.test.ts
@@ -1,4 +1,3 @@
-import type { NodeId } from 'polykey/dist/ids/types';
 import type { Host } from 'polykey/dist/network/types';
 import path from 'path';
 import fs from 'fs';
@@ -92,13 +91,7 @@ describe('add', () => {
     'fails to add a node (invalid node ID)',
     async () => {
       const { exitCode } = await testUtils.pkStdio(
-        [
-          'nodes',
-          'add',
-          'INVALIDNODEID',
-          validHost,
-          `${port}`,
-        ],
+        ['nodes', 'add', 'INVALIDNODEID', validHost, `${port}`],
         {
           env: {
             PK_NODE_PATH: nodePath,

--- a/tests/nodes/find.test.ts
+++ b/tests/nodes/find.test.ts
@@ -63,8 +63,8 @@ describe('find', () => {
       },
     });
     remoteOnlineNodeId = remoteOnline.keyRing.getNodeId();
-    remoteOnlineHost = remoteOnline.quicServerAgent.host as unknown as Host;
-    remoteOnlinePort = remoteOnline.quicServerAgent.port as unknown as Port;
+    remoteOnlineHost = remoteOnline.quicSocket.host as unknown as Host;
+    remoteOnlinePort = remoteOnline.quicSocket.port as unknown as Port;
     await testUtils.nodesConnect(polykeyAgent, remoteOnline);
     // Setting up an offline remote keynode
     remoteOffline = await PolykeyAgent.createPolykeyAgent({
@@ -82,8 +82,8 @@ describe('find', () => {
       },
     });
     remoteOfflineNodeId = remoteOffline.keyRing.getNodeId();
-    remoteOfflineHost = remoteOffline.quicServerAgent.host as unknown as Host;
-    remoteOfflinePort = remoteOffline.quicServerAgent.port as unknown as Port;
+    remoteOfflineHost = remoteOffline.quicSocket.host as unknown as Host;
+    remoteOfflinePort = remoteOffline.quicSocket.port as unknown as Port;
     await testUtils.nodesConnect(polykeyAgent, remoteOffline);
     await remoteOffline.stop();
   });

--- a/tests/sessions.test.ts
+++ b/tests/sessions.test.ts
@@ -43,7 +43,7 @@ describe('sessions', () => {
     'serial commands refresh the session token',
     async () => {
       const session = await Session.createSession({
-        sessionTokenPath: path.join(agentDir, config.defaults.tokenBase),
+        sessionTokenPath: path.join(agentDir, config.paths.tokenBase),
         fs,
         logger,
       });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,5 +1,6 @@
 import type { Host, Port } from 'polykey/dist/network/types';
 import ErrorPolykey from 'polykey/dist/ErrorPolykey';
+import * as ids from 'polykey/dist/ids';
 import * as nodesUtils from 'polykey/dist/nodes/utils';
 import * as rpcErrors from 'polykey/dist/rpc/errors';
 import * as binUtils from '@/utils/utils';
@@ -87,11 +88,12 @@ describe('bin/utils', () => {
   testUtils.testIf(testUtils.isTestPlatformEmpty)(
     'errors in human and json format',
     () => {
+      const nodeIdGenerator = ids.createNodeIdGenerator();
       const timestamp = new Date();
       const data = { string: 'one', number: 1 };
       const host = '127.0.0.1' as Host;
       const port = 55555 as Port;
-      const nodeId = testUtils.generateRandomNodeId();
+      const nodeId = nodeIdGenerator();
       const standardError = new TypeError('some error');
       const pkError = new ErrorPolykey<undefined>('some pk error', {
         timestamp,

--- a/tests/utils/utils.ts
+++ b/tests/utils/utils.ts
@@ -76,13 +76,13 @@ function trackTimers() {
 async function nodesConnect(localNode: PolykeyAgent, remoteNode: PolykeyAgent) {
   // Add remote node's details to local node
   await localNode.nodeManager.setNode(remoteNode.keyRing.getNodeId(), {
-    host: remoteNode.quicServerAgent.host as unknown as Host,
-    port: remoteNode.quicServerAgent.port as unknown as Port,
+    host: remoteNode.quicSocket.host as unknown as Host,
+    port: remoteNode.quicSocket.port as unknown as Port,
   } as NodeAddress);
   // Add local node's details to remote node
   await remoteNode.nodeManager.setNode(localNode.keyRing.getNodeId(), {
-    host: localNode.quicServerAgent.host as unknown as Host,
-    port: localNode.quicServerAgent.port as unknown as Port,
+    host: localNode.quicSocket.host as unknown as Host,
+    port: localNode.quicSocket.port as unknown as Port,
   } as NodeAddress);
 }
 

--- a/tests/utils/utils.ts
+++ b/tests/utils/utils.ts
@@ -1,15 +1,7 @@
-import type { NodeId } from 'polykey/dist/ids/types';
 import type PolykeyAgent from 'polykey/dist/PolykeyAgent';
 import type { Host, Port } from 'polykey/dist/network/types';
 import type { NodeAddress } from 'polykey/dist/nodes/types';
-import { IdInternal } from '@matrixai/id';
-import * as keysUtils from 'polykey/dist/keys/utils';
 import { promise } from 'polykey/dist/utils/utils';
-
-function generateRandomNodeId(): NodeId {
-  const random = keysUtils.getRandomBytes(16).toString('hex');
-  return IdInternal.fromString<NodeId>(random);
-}
 
 function testIf(condition: boolean) {
   return condition ? test : test.skip;
@@ -86,4 +78,4 @@ async function nodesConnect(localNode: PolykeyAgent, remoteNode: PolykeyAgent) {
   } as NodeAddress);
 }
 
-export { generateRandomNodeId, testIf, describeIf, trackTimers, nodesConnect };
+export { testIf, describeIf, trackTimers, nodesConnect };

--- a/tests/vaults/vaults.test.ts
+++ b/tests/vaults/vaults.test.ts
@@ -256,14 +256,14 @@ describe('CLI vaults', () => {
       const targetNodeId = targetPolykeyAgent.keyRing.getNodeId();
       const targetNodeIdEncoded = nodesUtils.encodeNodeId(targetNodeId);
       await polykeyAgent.nodeManager.setNode(targetNodeId, {
-        host: targetPolykeyAgent.quicServerAgent.host as unknown as Host,
-        port: targetPolykeyAgent.quicServerAgent.port as unknown as Port,
+        host: targetPolykeyAgent.quicSocket.host as unknown as Host,
+        port: targetPolykeyAgent.quicSocket.port as unknown as Port,
       });
       await targetPolykeyAgent.nodeManager.setNode(
         polykeyAgent.keyRing.getNodeId(),
         {
-          host: polykeyAgent.quicServerAgent.host as unknown as Host,
-          port: polykeyAgent.quicServerAgent.port as unknown as Port,
+          host: polykeyAgent.quicSocket.host as unknown as Host,
+          port: polykeyAgent.quicSocket.port as unknown as Port,
         },
       );
       await polykeyAgent.acl.setNodePerm(targetNodeId, {
@@ -835,8 +835,8 @@ describe('CLI vaults', () => {
           const remoteOnlineNodeIdEncoded =
             nodesUtils.encodeNodeId(remoteOnlineNodeId);
           await polykeyAgent.nodeManager.setNode(remoteOnlineNodeId, {
-            host: remoteOnline.quicServerAgent.host as unknown as Host,
-            port: remoteOnline.quicServerAgent.port as unknown as Port,
+            host: remoteOnline.quicSocket.host as unknown as Host,
+            port: remoteOnline.quicSocket.port as unknown as Port,
           } as NodeAddress);
 
           await remoteOnline.gestaltGraph.setNode({

--- a/tests/vaults/vaults.test.ts
+++ b/tests/vaults/vaults.test.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import fs from 'fs';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import PolykeyAgent from 'polykey/dist/PolykeyAgent';
+import * as ids from 'polykey/dist/ids';
 import * as nodesUtils from 'polykey/dist/nodes/utils';
 import * as vaultsUtils from 'polykey/dist/vaults/utils';
 import sysexits from 'polykey/dist/utils/sysexits';
@@ -22,11 +23,10 @@ describe('CLI vaults', () => {
   let command: Array<string>;
   let vaultNumber: number;
   let vaultName: VaultName;
-
-  const nodeId1 = testUtils.generateRandomNodeId();
-  const nodeId2 = testUtils.generateRandomNodeId();
-  const nodeId3 = testUtils.generateRandomNodeId();
-
+  const nodeIdGenerator = ids.createNodeIdGenerator();
+  const nodeId1 = nodeIdGenerator();
+  const nodeId2 = nodeIdGenerator();
+  const nodeId3 = nodeIdGenerator();
   const node1: GestaltNodeInfo = {
     nodeId: nodeId1,
   };
@@ -36,13 +36,11 @@ describe('CLI vaults', () => {
   const node3: GestaltNodeInfo = {
     nodeId: nodeId3,
   };
-
   // Helper functions
   function genVaultName() {
     vaultNumber++;
     return `vault-${vaultNumber}` as VaultName;
   }
-
   beforeEach(async () => {
     dataDir = await fs.promises.mkdtemp(
       path.join(globalThis.tmpDir, 'polykey-test-'),
@@ -408,7 +406,7 @@ describe('CLI vaults', () => {
             vaultName,
           );
           const vaultIdEncoded = vaultsUtils.encodeVaultId(vaultId);
-          const targetNodeId = testUtils.generateRandomNodeId();
+          const targetNodeId = nodeIdGenerator();
           const targetNodeIdEncoded = nodesUtils.encodeNodeId(targetNodeId);
           await polykeyAgent.gestaltGraph.setNode({
             nodeId: targetNodeId,
@@ -454,7 +452,7 @@ describe('CLI vaults', () => {
         );
         const vaultIdEncoded1 = vaultsUtils.encodeVaultId(vaultId1);
         const vaultIdEncoded2 = vaultsUtils.encodeVaultId(vaultId2);
-        const targetNodeId = testUtils.generateRandomNodeId();
+        const targetNodeId = nodeIdGenerator();
         const targetNodeIdEncoded = nodesUtils.encodeNodeId(targetNodeId);
         await polykeyAgent.gestaltGraph.setNode({
           nodeId: targetNodeId,
@@ -533,7 +531,7 @@ describe('CLI vaults', () => {
         );
         const vaultIdEncoded1 = vaultsUtils.encodeVaultId(vaultId1);
         const vaultIdEncoded2 = vaultsUtils.encodeVaultId(vaultId2);
-        const targetNodeId = testUtils.generateRandomNodeId();
+        const targetNodeId = nodeIdGenerator();
         const targetNodeIdEncoded = nodesUtils.encodeNodeId(targetNodeId);
         await polykeyAgent.gestaltGraph.setNode({
           nodeId: targetNodeId,


### PR DESCRIPTION
### Description

Clean up after extraction.

### Tasks

- [x] 1. `@matrixai/quic` configuration should be encapsulated by the PK library, PK CLI should not have any knowledge about QUIC
- [x] 2. The `@matrixai/id` can be replaced by the new node ID utils `encodeNodeIdString`, `decodeNodeIdString` and `createNodeIdGenerator`.
- [x] 3. The error tree under `Polykey-CLI` should be separate. It should not be extending the library. It is its own thing. I believe it can be organised under `ErrorPolykeyCLI`.
  - And the naming of the errors should probably be simplified, with either a plain prefix of the relevant domains or just a suffix. I think in the case of CLI, a plain suffix is fine. Like `ErrorPolykeyCLI...`

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* ~Domain specific tests~
* ~Full tests~
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
