### PR TITLE
Fixing identities claim to be in-line with identities discover and identities trust, by introducing a new parser parseGestaltIdentityId

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "nexpect": "^0.6.0",
         "node-gyp-build": "^4.4.0",
         "nodemon": "^3.0.1",
-        "polykey": "^1.2.1-alpha.17",
+        "polykey": "^1.2.1-alpha.19",
         "prettier": "^3.0.0",
         "shelljs": "^0.8.5",
         "shx": "^0.3.4",
@@ -7429,9 +7429,9 @@
       }
     },
     "node_modules/polykey": {
-      "version": "1.2.1-alpha.17",
-      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.2.1-alpha.17.tgz",
-      "integrity": "sha512-oj9+ZPKeq//nRg4FZGY0yBIBfliGycJqV66gneFqk6fYOpD4hp/ltlvpgR73CHzHrvARbEQFDU7rHnw5HUY/fQ==",
+      "version": "1.2.1-alpha.19",
+      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.2.1-alpha.19.tgz",
+      "integrity": "sha512-V2NrX+juze5aAKZ5s43pVBmBr4qZmRPUSIPUa4kpW1xME8Snl+QMTOTn6j0UXovnZ0xxXsvl65ZDmSTIa4iKog==",
       "dev": true,
       "dependencies": {
         "@matrixai/async-cancellable": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@matrixai/errors": "^1.2.0",
     "@matrixai/logger": "^3.1.0",
     "commander": "^8.3.0",
-    "polykey": "^1.2.1-alpha.17",
+    "polykey": "^1.2.1-alpha.19",
     "threads": "^1.6.5",
     "@swc/core": "1.3.82",
     "@swc/jest": "^0.2.29",

--- a/src/identities/CommandClaim.ts
+++ b/src/identities/CommandClaim.ts
@@ -1,4 +1,5 @@
 import type PolykeyClient from 'polykey/dist/PolykeyClient';
+import type { ProviderIdentityId } from 'polykey/dist/ids';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
@@ -11,71 +12,69 @@ class CommandClaim extends CommandPolykey {
     this.name('claim');
     this.description('Claim a Digital Identity for this Keynode');
     this.argument(
-      '<providerId>',
+      '<providerIdentityId>',
       'Name of the digital identity provider',
-      binParsers.parseProviderId,
-    );
-    this.argument(
-      '<identityId>',
-      'Digital identity to claim',
-      binParsers.parseIdentityId,
+      binParsers.parseGestaltIdentityId,
     );
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
-    this.action(async (providerId, identityId, options) => {
-      const { default: PolykeyClient } = await import(
-        'polykey/dist/PolykeyClient'
-      );
-      const clientOptions = await binProcessors.processClientOptions(
-        options.nodePath,
-        options.nodeId,
-        options.clientHost,
-        options.clientPort,
-        this.fs,
-        this.logger.getChild(binProcessors.processClientOptions.name),
-      );
-      const auth = await binProcessors.processAuthentication(
-        options.passwordFile,
-        this.fs,
-      );
-      let pkClient: PolykeyClient;
-      this.exitHandlers.handlers.push(async () => {
-        if (pkClient != null) await pkClient.stop();
-      });
-      try {
-        pkClient = await PolykeyClient.createPolykeyClient({
-          nodeId: clientOptions.nodeId,
-          host: clientOptions.clientHost,
-          port: clientOptions.clientPort,
-          options: {
-            nodePath: options.nodePath,
-          },
-          logger: this.logger.getChild(PolykeyClient.name),
+    this.action(
+      async (providerIdentityId: ['identity', ProviderIdentityId], options) => {
+        const { default: PolykeyClient } = await import(
+          'polykey/dist/PolykeyClient'
+        );
+        const clientOptions = await binProcessors.processClientOptions(
+          options.nodePath,
+          options.nodeId,
+          options.clientHost,
+          options.clientPort,
+          this.fs,
+          this.logger.getChild(binProcessors.processClientOptions.name),
+        );
+        const auth = await binProcessors.processAuthentication(
+          options.passwordFile,
+          this.fs,
+        );
+        let pkClient: PolykeyClient;
+        this.exitHandlers.handlers.push(async () => {
+          if (pkClient != null) await pkClient.stop();
         });
-        const claimMessage = await binUtils.retryAuthentication(
-          (auth) =>
-            pkClient.rpcClient.methods.identitiesClaim({
-              metadata: auth,
-              providerId: providerId,
-              identityId: identityId,
+        try {
+          pkClient = await PolykeyClient.createPolykeyClient({
+            nodeId: clientOptions.nodeId,
+            host: clientOptions.clientHost,
+            port: clientOptions.clientPort,
+            options: {
+              nodePath: options.nodePath,
+            },
+            logger: this.logger.getChild(PolykeyClient.name),
+          });
+          const [providerId, identityId] = providerIdentityId[1];
+          const claimMessage = await binUtils.retryAuthentication(
+            (auth) =>
+              pkClient.rpcClient.methods.identitiesClaim({
+                metadata: auth,
+                providerId: providerId,
+                identityId: identityId,
+              }),
+            auth,
+          );
+          const output = [`Claim Id: ${claimMessage.claimId}`];
+          if (claimMessage.url) {
+            output.push(`Url: ${claimMessage.url}`);
+          }
+          process.stdout.write(
+            binUtils.outputFormatter({
+              type: options.format === 'json' ? 'json' : 'list',
+              data: output,
             }),
-          auth,
-        );
-        const output = [`Claim Id: ${claimMessage.claimId}`];
-        if (claimMessage.url) {
-          output.push(`Url: ${claimMessage.url}`);
+          );
+        } finally {
+          if (pkClient! != null) await pkClient.stop();
         }
-        process.stdout.write(
-          binUtils.outputFormatter({
-            type: options.format === 'json' ? 'json' : 'list',
-            data: output,
-          }),
-        );
-      } finally {
-        if (pkClient! != null) await pkClient.stop();
-      }
-    });
+      },
+    );
   }
 }
 

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -78,36 +78,52 @@ function parseSecretPath(secretPath: string): [string, string, string?] {
 const parseInteger: (data: string) => number = validateParserToArgParser(
   validationUtils.parseInteger,
 );
+
 const parseNumber: (data: string) => number = validateParserToArgParser(
   validationUtils.parseNumber,
 );
+
 const parseNodeId: (data: string) => ids.NodeId = validateParserToArgParser(
   ids.parseNodeId,
 );
+
 const parseGestaltId: (data: string) => ids.GestaltId =
   validateParserToArgParser(ids.parseGestaltId);
+
+const parseGestaltIdentityId: (data: string) => ids.GestaltId =
+  validateParserToArgParser(ids.parseGestaltIdentityId);
+
 const parseProviderId: (data: string) => ids.ProviderId =
   validateParserToArgParser(ids.parseProviderId);
+
 const parseIdentityId: (data: string) => ids.IdentityId =
   validateParserToArgParser(ids.parseIdentityId);
+
 const parseProviderIdList: (data: string) => ids.ProviderId[] =
   validateParserToArgListParser(ids.parseProviderId);
+
 const parseGestaltAction: (data: string) => 'notify' | 'scan' | 'claim' =
   validateParserToArgParser(gestaltsUtils.parseGestaltAction);
+
 const parseHost: (data: string) => Host = validateParserToArgParser(
   networkUtils.parseHost,
 );
+
 const parseHostname: (data: string) => Hostname = validateParserToArgParser(
   networkUtils.parseHostname,
 );
+
 const parseHostOrHostname: (data: string) => Host | Hostname =
   validateParserToArgParser(networkUtils.parseHostOrHostname);
+
 const parsePort: (data: string) => Port = validateParserToArgParser(
   networkUtils.parsePort,
 );
+
 const parseNetwork: (data: string) => SeedNodes = validateParserToArgParser(
   nodesUtils.parseNetwork,
 );
+
 const parseSeedNodes: (data: string) => [SeedNodes, boolean] =
   validateParserToArgParser(nodesUtils.parseSeedNodes);
 
@@ -120,6 +136,7 @@ export {
   parseNumber,
   parseNodeId,
   parseGestaltId,
+  parseGestaltIdentityId,
   parseGestaltAction,
   parseHost,
   parseHostname,

--- a/tests/identities/claim.test.ts
+++ b/tests/identities/claim.test.ts
@@ -81,8 +81,7 @@ describe('claim', () => {
         [
           'identities',
           'claim',
-          testToken.providerId,
-          testToken.identityId,
+          `${testToken.providerId}:${testToken.identityId}`,
           '--format',
           'json',
         ],
@@ -110,7 +109,11 @@ describe('claim', () => {
     'cannot claim unauthenticated identities',
     async () => {
       const { exitCode } = await testUtils.pkStdio(
-        ['identities', 'claim', testToken.providerId, testToken.identityId],
+        [
+          'identities',
+          'claim',
+          `${testToken.providerId}:${testToken.identityId}`,
+        ],
         {
           env: {
             PK_NODE_PATH: nodePath,
@@ -128,7 +131,7 @@ describe('claim', () => {
       let exitCode;
       // Invalid provider
       ({ exitCode } = await testUtils.pkStdio(
-        ['identities', 'claim', '', testToken.identityId],
+        ['identities', 'claim', `:${testToken.identityId}`],
         {
           env: {
             PK_NODE_PATH: nodePath,
@@ -140,7 +143,7 @@ describe('claim', () => {
       expect(exitCode).toBe(sysexits.USAGE);
       // Invalid identity
       ({ exitCode } = await testUtils.pkStdio(
-        ['identities', 'claim', testToken.providerId, ''],
+        ['identities', 'claim', `${testToken.providerId}:`],
         {
           env: {
             PK_NODE_PATH: nodePath,


### PR DESCRIPTION
### Description

The `pk identities claim` currently takes two parameters in order to claim an identity. 

```
pk identities claim github.com cmcdragonkai
```

This is not consistent with other two commands `trust` and `discover`. 

```
pk identities trust github.com:cmcdragonkai
pk identities discover github.com:cmcdragonkai
```

These two commands are not using the `ProviderIdentityId` type. 

```
type ProviderIdentityId = [ProviderId, IdentityId];
```

This is because the encoded form of this type is `["github.com", "cmcdragonkai"]`.

Instead we need to use a parser similar to `binParsers.parseGestaltId`  (which is used by the trust and discover commands), however this parser, parses both node IDs and identities. 

What we need to do is to extract the identity parsing portion of `binParsers.parseGestaltId`.

```typescript
function parseGestaltId(data: any): GestaltId {
  if (typeof data !== 'string') {
    throw new validationErrors.ErrorParse('Gestalt ID must be string');
  }
  const nodeId = decodeNodeId(data);
  if (nodeId != null) {
    return ['node', nodeId];
  }
  const match = (data as string).match(/^(.+):(.+)$/);
  if (match == null) {
    throw new validationErrors.ErrorParse(
      'Gestalt ID must be either a Node ID or `Provider ID:Identity ID`',
    );
  }
  const providerId = parseProviderId(match[1]);
  const identityId = parseIdentityId(match[2]);
  return ['identity', [providerId, identityId]];
}
```

It will be:

```ts
  const match = (data as string).match(/^(.+):(.+)$/);
  if (match == null) {
    throw new validationErrors.ErrorParse(
      'Gestalt ID must be either a Node ID or `Provider ID:Identity ID`',
    );
  }
  const providerId = parseProviderId(match[1]);
  const identityId = parseIdentityId(match[2]);
  return ['identity', [providerId, identityId]];
```

This will be called `parseGestaltIdentityId`.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #28 

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Alter handler call.
- [x] 2. Alter args.

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
