### PR TITLE
Feature cli polish

### DIFF
--- a/src/agent/CommandStatus.ts
+++ b/src/agent/CommandStatus.ts
@@ -79,8 +79,6 @@ class CommandStatus extends CommandPolykey {
               clientPort: response.clientPort,
               agentHost: response.agentHost,
               agentPort: response.agentPort,
-              publicKeyJWK: response.publicKeyJwk,
-              certChainPEM: response.certChainPEM,
             },
           }),
         );

--- a/src/nodes/CommandClaim.ts
+++ b/src/nodes/CommandClaim.ts
@@ -65,27 +65,25 @@ class CommandClaim extends CommandPolykey {
         );
         const claimed = response.success;
         if (claimed) {
-          process.stdout.write(
-            binUtils.outputFormatter({
-              type: options.format === 'json' ? 'json' : 'list',
-              data: [
-                `Successfully generated a cryptolink claim on Keynode with ID ${nodesUtils.encodeNodeId(
-                  nodeId,
-                )}`,
-              ],
-            }),
-          );
+          const formattedOutput = await binUtils.outputFormatter({
+            type: options.format === 'json' ? 'json' : 'list',
+            data: [
+              `Successfully generated a cryptolink claim on Keynode with ID ${nodesUtils.encodeNodeId(
+                nodeId,
+              )}`,
+            ],
+          });
+          process.stdout.write(formattedOutput);
         } else {
-          process.stdout.write(
-            binUtils.outputFormatter({
-              type: options.format === 'json' ? 'json' : 'list',
-              data: [
-                `Successfully sent Gestalt Invite notification to Keynode with ID ${nodesUtils.encodeNodeId(
-                  nodeId,
-                )}`,
-              ],
-            }),
-          );
+          const formattedOutput = await binUtils.outputFormatter({
+            type: options.format === 'json' ? 'json' : 'list',
+            data: [
+              `Successfully sent Gestalt Invite notification to Keynode with ID ${nodesUtils.encodeNodeId(
+                nodeId,
+              )}`,
+            ],
+          });
+          process.stdout.write(formattedOutput);
         }
       } finally {
         if (pkClient! != null) await pkClient.stop();

--- a/src/nodes/CommandFind.ts
+++ b/src/nodes/CommandFind.ts
@@ -90,12 +90,11 @@ class CommandFind extends CommandPolykey {
         }
         let output: any = result;
         if (options.format === 'human') output = [result.message];
-        process.stdout.write(
-          binUtils.outputFormatter({
-            type: options.format === 'json' ? 'json' : 'list',
-            data: output,
-          }),
-        );
+        const formattedOutput = await binUtils.outputFormatter({
+          type: options.format === 'json' ? 'json' : 'list',
+          data: output,
+        });
+        process.stdout.write(formattedOutput);
         // Like ping it should error when failing to find node for automation reasons.
         if (!result.success) {
           throw new errors.ErrorPolykeyCLINodeFindFailed(result.message);

--- a/src/nodes/CommandGetAll.ts
+++ b/src/nodes/CommandGetAll.ts
@@ -60,12 +60,11 @@ class CommandGetAll extends CommandPolykey {
               `NodeId ${value.nodeIdEncoded}, Address ${value.host}:${value.port}, bucketIndex ${value.bucketIndex}`,
           );
         }
-        process.stdout.write(
-          binUtils.outputFormatter({
-            type: options.format === 'json' ? 'json' : 'list',
-            data: output,
-          }),
-        );
+        const formattedOutput = await binUtils.outputFormatter({
+          type: options.format === 'json' ? 'json' : 'list',
+          data: output,
+        });
+        process.stdout.write(formattedOutput);
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/nodes/CommandPing.ts
+++ b/src/nodes/CommandPing.ts
@@ -68,12 +68,12 @@ class CommandPing extends CommandPolykey {
         else status.message = error.message;
         const output: any =
           options.format === 'json' ? status : [status.message];
-        process.stdout.write(
-          binUtils.outputFormatter({
-            type: options.format === 'json' ? 'json' : 'list',
-            data: output,
-          }),
-        );
+        const formattedOutput = await binUtils.outputFormatter({
+          type: options.format === 'json' ? 'json' : 'list',
+          data: output,
+        });
+        process.stdout.write(formattedOutput);
+
         if (error != null) throw error;
       } finally {
         if (pkClient! != null) await pkClient.stop();

--- a/src/notifications/CommandRead.ts
+++ b/src/notifications/CommandRead.ts
@@ -79,12 +79,11 @@ class CommandRead extends CommandPolykey {
           notifications.push(notification);
         }
         for (const notification of notifications) {
-          process.stdout.write(
-            binUtils.outputFormatter({
-              type: options.format === 'json' ? 'json' : 'dict',
-              data: notification,
-            }),
-          );
+          const formattedOutput = await binUtils.outputFormatter({
+            type: options.format === 'json' ? 'json' : 'dict',
+            data: notification,
+          });
+          process.stdout.write(formattedOutput);
         }
       } finally {
         if (pkClient! != null) await pkClient.stop();

--- a/src/secrets/CommandGet.ts
+++ b/src/secrets/CommandGet.ts
@@ -59,12 +59,11 @@ class CommandGet extends CommandPolykey {
           meta,
         );
         const secretContent = Buffer.from(response.secretContent, 'binary');
-        process.stdout.write(
-          binUtils.outputFormatter({
-            type: 'raw',
-            data: secretContent,
-          }),
-        );
+        const formattedOutput = await binUtils.outputFormatter({
+          type: 'raw',
+          data: secretContent,
+        });
+        process.stdout.write(formattedOutput);
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/secrets/CommandList.ts
+++ b/src/secrets/CommandList.ts
@@ -56,12 +56,13 @@ class CommandList extends CommandPolykey {
           }
           return data;
         }, auth);
-        process.stdout.write(
-          binUtils.outputFormatter({
-            type: options.format === 'json' ? 'json' : 'list',
-            data: data,
-          }),
-        );
+
+        const formattedOutput = await binUtils.outputFormatter({
+          type: options.format === 'json' ? 'json' : 'list',
+          data: data,
+        });
+
+        process.stdout.write(formattedOutput);
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/secrets/CommandStat.ts
+++ b/src/secrets/CommandStat.ts
@@ -65,13 +65,13 @@ class CommandStat extends CommandPolykey {
           data.push(`${key}: ${value}`);
         }
 
-        // Print out the result.
-        process.stdout.write(
-          binUtils.outputFormatter({
-            type: options.format === 'json' ? 'json' : 'list',
-            data,
-          }),
-        );
+        // Assuming the surrounding function is async
+        const formattedOutput = await binUtils.outputFormatter({
+          type: options.format === 'json' ? 'json' : 'list',
+          data,
+        });
+
+        process.stdout.write(formattedOutput);
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,8 +40,17 @@ type AgentChildProcessOutput =
       error: POJO;
     };
 
+type TableRow = Record<string, any>;
+
+interface TableOptions {
+  headers?: string[];
+  includeRowCount?: boolean;
+}
+
 export type {
   AgentStatusLiveData,
   AgentChildProcessInput,
   AgentChildProcessOutput,
+  TableRow,
+  TableOptions,
 };

--- a/src/vaults/CommandCreate.ts
+++ b/src/vaults/CommandCreate.ts
@@ -1,4 +1,5 @@
 import type PolykeyClient from 'polykey/dist/PolykeyClient';
+import process from 'process';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
@@ -53,12 +54,11 @@ class CommandCreate extends CommandPolykey {
             }),
           meta,
         );
-        process.stdout.write(
-          binUtils.outputFormatter({
-            type: options.format === 'json' ? 'json' : 'list',
-            data: [`Vault ${response.vaultIdEncoded} created successfully`],
-          }),
-        );
+        const formattedOutput = await binUtils.outputFormatter({
+          type: options.format === 'json' ? 'json' : 'list',
+          data: [`Vault ${response.vaultIdEncoded} created successfully`],
+        });
+        process.stdout.write(formattedOutput);
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/vaults/CommandList.ts
+++ b/src/vaults/CommandList.ts
@@ -1,4 +1,5 @@
 import type PolykeyClient from 'polykey/dist/PolykeyClient';
+import process from 'process';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
@@ -55,12 +56,11 @@ class CommandList extends CommandPolykey {
           }
           return data;
         }, meta);
-        process.stdout.write(
-          binUtils.outputFormatter({
-            type: options.format === 'json' ? 'json' : 'list',
-            data: data,
-          }),
-        );
+        const formattedOutput = await binUtils.outputFormatter({
+          type: options.format === 'json' ? 'json' : 'list',
+          data: data,
+        });
+        process.stdout.write(formattedOutput);
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/vaults/CommandLog.ts
+++ b/src/vaults/CommandLog.ts
@@ -1,4 +1,5 @@
 import type PolykeyClient from 'polykey/dist/PolykeyClient';
+import process from 'process';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
@@ -62,12 +63,11 @@ class CommandLog extends CommandPolykey {
           }
           return data;
         }, meta);
-        process.stdout.write(
-          binUtils.outputFormatter({
-            type: options.format === 'json' ? 'json' : 'list',
-            data: data,
-          }),
-        );
+        const formattedOutput = await binUtils.outputFormatter({
+          type: options.format === 'json' ? 'json' : 'list',
+          data: data,
+        });
+        process.stdout.write(formattedOutput);
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/vaults/CommandPermissions.ts
+++ b/src/vaults/CommandPermissions.ts
@@ -61,12 +61,11 @@ class CommandPermissions extends CommandPolykey {
         }, meta);
 
         if (data.length === 0) data.push('No permissions were found');
-        process.stdout.write(
-          binUtils.outputFormatter({
-            type: options.format === 'json' ? 'json' : 'list',
-            data: data,
-          }),
-        );
+        const formattedOutput = await binUtils.outputFormatter({
+          type: options.format === 'json' ? 'json' : 'list',
+          data: data,
+        });
+        process.stdout.write(formattedOutput);
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/vaults/CommandScan.ts
+++ b/src/vaults/CommandScan.ts
@@ -58,12 +58,11 @@ class CommandScan extends CommandPolykey {
           }
           return data;
         }, meta);
-        process.stdout.write(
-          binUtils.outputFormatter({
-            type: options.format === 'json' ? 'json' : 'list',
-            data: data,
-          }),
-        );
+        const formattedOutput = await binUtils.outputFormatter({
+          type: options.format === 'json' ? 'json' : 'list',
+          data: data,
+        });
+        process.stdout.write(formattedOutput);
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/tests/agent/status.test.ts
+++ b/tests/agent/status.test.ts
@@ -179,8 +179,6 @@ describe('status', () => {
         clientPort: statusInfo.data.clientPort,
         agentHost: statusInfo.data.agentHost,
         agentPort: statusInfo.data.agentPort,
-        publicKeyJWK: expect.any(Object),
-        certChainPEM: expect.any(String),
       });
     });
     testUtils.testIf(
@@ -229,8 +227,6 @@ describe('status', () => {
         clientPort: statusInfo.data.clientPort,
         agentHost: statusInfo.data.agentHost,
         agentPort: statusInfo.data.agentPort,
-        publicKeyJWK: expect.any(Object),
-        certChainPEM: expect.any(String),
       });
     });
   });

--- a/tests/keys/cert.test.ts
+++ b/tests/keys/cert.test.ts
@@ -33,7 +33,7 @@ describe('cert', () => {
     });
     const certCommand = JSON.parse(stdout).cert;
     ({ exitCode, stdout } = await testUtils.pkExec(
-      ['agent', 'status', '--format', 'json'],
+      ['keys', 'cert', '--format', 'json'],
       {
         env: {
           PK_NODE_PATH: agentDir,
@@ -44,7 +44,7 @@ describe('cert', () => {
       },
     ));
     expect(exitCode).toBe(0);
-    const certStatus = JSON.parse(stdout).certChainPEM;
+    const certStatus = JSON.parse(stdout).cert;
     expect(certCommand).toBe(certStatus);
   });
 });

--- a/tests/nodes/connections.test.ts
+++ b/tests/nodes/connections.test.ts
@@ -1,0 +1,129 @@
+import type { NodeId, NodeIdEncoded } from 'polykey/dist/ids/types';
+import path from 'path';
+import fs from 'fs';
+import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
+import PolykeyAgent from 'polykey/dist/PolykeyAgent';
+import * as nodesUtils from 'polykey/dist/nodes/utils';
+import * as keysUtils from 'polykey/dist/keys/utils';
+import * as testUtils from '../utils';
+
+describe('connections', () => {
+  const logger = new Logger('connections test', LogLevel.WARN, [
+    new StreamHandler(),
+  ]);
+  const password = 'helloworld';
+  let dataDir: string;
+  let nodePath: string;
+  let pkAgent: PolykeyAgent;
+  let remoteNode: PolykeyAgent;
+  let localId: NodeId;
+  let remoteId: NodeId;
+  let remoteIdEncoded: NodeIdEncoded;
+  beforeEach(async () => {
+    dataDir = await fs.promises.mkdtemp(
+      path.join(globalThis.tmpDir, 'polykey-test-'),
+    );
+    nodePath = path.join(dataDir, 'keynode');
+    pkAgent = await PolykeyAgent.createPolykeyAgent({
+      password,
+      options: {
+        seedNodes: {}, // Explicitly no seed nodes on startup
+        nodePath,
+        agentServiceHost: '127.0.0.1',
+        clientServiceHost: '127.0.0.1',
+        agentServicePort: 55555,
+        clientServicePort: 55554,
+        keys: {
+          passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+          passwordMemLimit: keysUtils.passwordMemLimits.min,
+          strictMemoryLock: false,
+        },
+      },
+      logger,
+    });
+    localId = pkAgent.keyRing.getNodeId();
+    // Setting up a remote keynode
+    remoteNode = await PolykeyAgent.createPolykeyAgent({
+      password,
+      options: {
+        seedNodes: {}, // Explicitly no seed nodes on startup
+        nodePath: path.join(dataDir, 'remoteNode'),
+        agentServiceHost: '127.0.0.1',
+        clientServiceHost: '127.0.0.1',
+        agentServicePort: 55553,
+        clientServicePort: 55552,
+        keys: {
+          passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+          passwordMemLimit: keysUtils.passwordMemLimits.min,
+          strictMemoryLock: false,
+        },
+      },
+      logger,
+    });
+    remoteId = remoteNode.keyRing.getNodeId();
+    remoteIdEncoded = nodesUtils.encodeNodeId(remoteId);
+    await testUtils.nodesConnect(pkAgent, remoteNode);
+    await pkAgent.acl.setNodePerm(remoteId, {
+      gestalt: {
+        notify: null,
+        claim: null,
+      },
+      vaults: {},
+    });
+    await remoteNode.acl.setNodePerm(localId, {
+      gestalt: {
+        notify: null,
+        claim: null,
+      },
+      vaults: {},
+    });
+  });
+  afterEach(async () => {
+    await pkAgent.stop();
+    await remoteNode.stop();
+    await fs.promises.rm(dataDir, {
+      force: true,
+      recursive: true,
+    });
+  });
+  test('Correctly list connection information, and not list auth data', async () => {
+    await remoteNode.notificationsManager.sendNotification(localId, {
+      type: 'GestaltInvite',
+    });
+    const { exitCode } = await testUtils.pkStdio(
+      ['nodes', 'claim', remoteIdEncoded, '--force-invite'],
+      {
+        env: {
+          PK_NODE_PATH: nodePath,
+          PK_PASSWORD: password,
+        },
+        cwd: dataDir,
+      },
+    );
+    const { stdout } = await testUtils.pkStdio(
+      ['nodes', 'connections', '--format', 'json'],
+      {
+        env: {
+          PK_NODE_PATH: nodePath,
+          PK_PASSWORD: password,
+        },
+        cwd: dataDir,
+      },
+    );
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          host: remoteNode.agentServiceHost,
+          hostname: '',
+          nodeIdEncoded: nodesUtils.encodeNodeId(
+            remoteNode.keyRing.getNodeId(),
+          ),
+          port: remoteNode.agentServicePort,
+          timeout: expect.any(Number),
+          usageCount: 0,
+        }),
+      ]),
+    );
+  });
+});

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -28,28 +28,32 @@ describe('bin/utils', () => {
   );
   testUtils.testIf(testUtils.isTestPlatformEmpty)(
     'table in human and in json format',
-    () => {
+    async () => {
+      // Note the async here
       // Table
-      expect(
-        binUtils.outputFormatter({
-          type: 'table',
-          data: [
-            { key1: 'value1', key2: 'value2' },
-            { key1: 'data1', key2: 'data2' },
-            { key1: null, key2: undefined },
-          ],
-        }),
-      ).toBe('key1\tkey2\nvalue1\tvalue2\ndata1\tdata2\n\t\n');
+      const tableOutput = await binUtils.outputFormatter({
+        // And the await here
+        type: 'table',
+        data: [
+          { key1: 'value1', key2: 'value2' },
+          { key1: 'data1', key2: 'data2' },
+          { key1: null, key2: undefined },
+        ],
+      });
+      expect(tableOutput).toBe(
+        'value1\tvalue2\ndata1 \tdata2\nundefined\tundefined\n',
+      );
+
       // JSON
-      expect(
-        binUtils.outputFormatter({
-          type: 'json',
-          data: [
-            { key1: 'value1', key2: 'value2' },
-            { key1: 'data1', key2: 'data2' },
-          ],
-        }),
-      ).toBe(
+      const jsonOutput = await binUtils.outputFormatter({
+        // And the await here
+        type: 'json',
+        data: [
+          { key1: 'value1', key2: 'value2' },
+          { key1: 'data1', key2: 'data2' },
+        ],
+      });
+      expect(jsonOutput).toBe(
         '[{"key1":"value1","key2":"value2"},{"key1":"data1","key2":"data2"}]\n',
       );
     },
@@ -63,19 +67,19 @@ describe('bin/utils', () => {
           type: 'dict',
           data: { key1: 'value1', key2: 'value2' },
         }),
-      ).toBe('key1\t"value1"\nkey2\t"value2"\n');
+      ).toBe('key1\tvalue1\nkey2\tvalue2\n');
       expect(
         binUtils.outputFormatter({
           type: 'dict',
           data: { key1: 'first\nsecond', key2: 'first\nsecond\n' },
         }),
-      ).toBe('key1\t"first\\nsecond"\nkey2\t"first\\nsecond\\n"\n');
+      ).toBe('key1\tfirst\\nsecond\nkey2\tfirst\\nsecond\\n\n');
       expect(
         binUtils.outputFormatter({
           type: 'dict',
           data: { key1: null, key2: undefined },
         }),
-      ).toBe('key1\t""\nkey2\t""\n');
+      ).toBe('key1\t\nkey2\t\n');
       // JSON
       expect(
         binUtils.outputFormatter({


### PR DESCRIPTION
### Description

This PR aims to fix a lot of UI/UX issues of Polykey CLI to improve clarity and security of command outputs.

The main issues to be fixed include: 

1. Fixes `nodes getall`:

This previous threw an error related to undefined host, this has now been resolved in the corresonding Polykey Handler by getting the valid address and port from the `info` field which is of type `NodeData`
```ts
          host: info.address.host,
          port: info.address.port,
```

2. Improve `nodes connections` Output: 

Previously, the output was rather unclear and lacked corresponding labels to relevant labels for `Node Host`, `UsageCount` and `Timeout`, now labels are added for the same.

Previously we used a hardcoded amount of tabbed spaces between columns, this has now been changed to be padded based on length of row with the max length.

```ts
// Old Code
const outputLine = `${hostString}\t${usageCount}\t${timeout}`;

// New Code
const outputLine = hostString.padEnd(maxHostStringLength) + "\t" + usageCount.padEnd(maxUsageCountLength) + "\t" + timeout.padEnd(maxTimeoutLength);
```

3. Sanitizing `JSON` formatted output for `nodes connections`:

This was a critical security issue where in the sensitive information of authentication data (although this is the user's authentication data itself) was being included in the JSON output, this has been sanitized out.

```ts
// Implementation Snippet
const sanitizedConnections = JSON.parse(JSON.stringify(connections));
delete connection.metadata;
```

4. Refactor `agent status` output:

JWK and PEM have very little usage in status, and correspondingly are being removed from agent status, this is a very simple fix of just removing the following keys from the output

```ts
// Old Code
data: { ... , publicKeyJWK: response.publicKeyJwk, certChainPEM: response.certChainPEM }

// New Code
data: { ... , /* publicKeyJWK and certChainPEM removed */ }
```

5. Additional scope added to this PR - Standardisation of table layout for `outputFormatter` : 

Table output in `outputFormatter` was intiially very static and did not take into account variety in terms of padding, this is altered now to allow field for headers, and a boolean to toggle numbering of rows. 

`Table` format now includes a standardised TSV padding.

`Table` format handles `\t` and `\n` by enclosing them in quotation marks to prevent disruption of the layout.

Additional supported is added for stream based padding to improve efficiency to `O(2n)`.

### Issues Fixed
* Related #44 

### Tasks
- [x] 1. `nodes connection` human format label.
- [x] 2. `nodes connection` json format remove metadata (sanitize).
- [x] 3. Remove `JWK` and `PEM` from `agent status`.
- [x] 4. Add a jest for `nodes connection`.
- [x] 5. Update jests which rely on `agent status`.

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
