### PR TITLE
`polykey identities authenticate` Timeout Upped to 2 Minutes

### DIFF
--- a/src/identities/CommandAuthenticate.ts
+++ b/src/identities/CommandAuthenticate.ts
@@ -62,6 +62,9 @@ class CommandAuthenticate extends CommandPolykey {
               metadata: auth,
               providerId: providerId,
             },
+            {
+              timer: 120000, // 2 minutes
+            },
           );
           for await (const message of genReadable) {
             if (message.request != null) {


### PR DESCRIPTION
### Description

The `polykey identities authenticate` command currently follows the default timeout of `RPCClient` (15 seconds). Since RPC changes have been made so that the call-site `ctx` can override the global timeout, it can be upped to 2 minutes without affecting the timeouts of other handlers.

### Issues Related
<!-- List all issues fixed by this PR. -->
* https://github.com/MatrixAI/Polykey/issues/588

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Bump `Polykey` version
- [x] 2. Add `{ timer: 120000 }` to `ctx` of `polykey identities authenticate` to extend timeout

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
