### PR TITLE
Fixing outputFormatter and standardising STDOUT

### DIFF
--- a/src/identities/CommandPermissions.ts
+++ b/src/identities/CommandPermissions.ts
@@ -52,7 +52,7 @@ class CommandPermissions extends CommandPolykey {
           logger: this.logger.getChild(PolykeyClient.name),
         });
         const [type, id] = gestaltId;
-        let actions: string[] = [];
+        let actions: Array<string> = [];
         switch (type) {
           case 'node':
             {

--- a/src/keys/CommandCert.ts
+++ b/src/keys/CommandCert.ts
@@ -54,7 +54,7 @@ class CommandCert extends CommandPolykey {
         };
         let output: any = result;
         if (options.format === 'human') {
-          output = [`Root certificate:\t\t${result.cert}`];
+          output = ['Root certificate:', result.cert];
         }
         process.stdout.write(
           binUtils.outputFormatter({

--- a/src/keys/CommandCertchain.ts
+++ b/src/keys/CommandCertchain.ts
@@ -57,7 +57,7 @@ class CommandsCertchain extends CommandPolykey {
         };
         let output: any = result;
         if (options.format === 'human') {
-          output = [`Root Certificate Chain:\t\t${result.certchain}`];
+          output = ['Root Certificate Chain:', ...result.certchain];
         }
         process.stdout.write(
           binUtils.outputFormatter({

--- a/src/keys/CommandDecrypt.ts
+++ b/src/keys/CommandDecrypt.ts
@@ -76,7 +76,7 @@ class CommandDecrypt extends CommandPolykey {
         };
         let output: any = result;
         if (options.format === 'human') {
-          output = [`Decrypted data:\t\t${result.decryptedData}`];
+          output = [`Decrypted data:${' '.repeat(4)}${result.decryptedData}`];
         }
         process.stdout.write(
           binUtils.outputFormatter({

--- a/src/keys/CommandEncrypt.ts
+++ b/src/keys/CommandEncrypt.ts
@@ -103,7 +103,7 @@ class CommandEncypt extends CommandPolykey {
         };
         let output: any = result;
         if (options.format === 'human') {
-          output = [`Encrypted data:\t\t${result.encryptedData}`];
+          output = [`Encrypted data:${' '.repeat(4)}${result.encryptedData}`];
         }
         process.stdout.write(
           binUtils.outputFormatter({

--- a/src/keys/CommandSign.ts
+++ b/src/keys/CommandSign.ts
@@ -76,7 +76,7 @@ class CommandSign extends CommandPolykey {
         };
         let output: any = result;
         if (options.format === 'human') {
-          output = [`Signature:\t\t${result.signature}`];
+          output = [`Signature:${' '.repeat(4)}${result.signature}`];
         }
         process.stdout.write(
           binUtils.outputFormatter({

--- a/src/keys/CommandVerify.ts
+++ b/src/keys/CommandVerify.ts
@@ -112,7 +112,9 @@ class CommandVerify extends CommandPolykey {
         };
         let output: any = result;
         if (options.format === 'human') {
-          output = [`Signature verified:\t\t${result.signatureVerified}`];
+          output = [
+            `Signature verified:${' '.repeat(4)}${result.signatureVerified}`,
+          ];
         }
         process.stdout.write(
           binUtils.outputFormatter({

--- a/src/nodes/CommandClaim.ts
+++ b/src/nodes/CommandClaim.ts
@@ -65,7 +65,7 @@ class CommandClaim extends CommandPolykey {
         );
         const claimed = response.success;
         if (claimed) {
-          const formattedOutput = await binUtils.outputFormatter({
+          const formattedOutput = binUtils.outputFormatter({
             type: options.format === 'json' ? 'json' : 'list',
             data: [
               `Successfully generated a cryptolink claim on Keynode with ID ${nodesUtils.encodeNodeId(
@@ -75,7 +75,7 @@ class CommandClaim extends CommandPolykey {
           });
           process.stdout.write(formattedOutput);
         } else {
-          const formattedOutput = await binUtils.outputFormatter({
+          const formattedOutput = binUtils.outputFormatter({
             type: options.format === 'json' ? 'json' : 'list',
             data: [
               `Successfully sent Gestalt Invite notification to Keynode with ID ${nodesUtils.encodeNodeId(

--- a/src/nodes/CommandClaim.ts
+++ b/src/nodes/CommandClaim.ts
@@ -65,7 +65,7 @@ class CommandClaim extends CommandPolykey {
         );
         const claimed = response.success;
         if (claimed) {
-          const formattedOutput = binUtils.outputFormatter({
+          const outputFormatted = binUtils.outputFormatter({
             type: options.format === 'json' ? 'json' : 'list',
             data: [
               `Successfully generated a cryptolink claim on Keynode with ID ${nodesUtils.encodeNodeId(
@@ -73,9 +73,9 @@ class CommandClaim extends CommandPolykey {
               )}`,
             ],
           });
-          process.stdout.write(formattedOutput);
+          process.stdout.write(outputFormatted);
         } else {
-          const formattedOutput = binUtils.outputFormatter({
+          const outputFormatted = binUtils.outputFormatter({
             type: options.format === 'json' ? 'json' : 'list',
             data: [
               `Successfully sent Gestalt Invite notification to Keynode with ID ${nodesUtils.encodeNodeId(
@@ -83,7 +83,7 @@ class CommandClaim extends CommandPolykey {
               )}`,
             ],
           });
-          process.stdout.write(formattedOutput);
+          process.stdout.write(outputFormatted);
         }
       } finally {
         if (pkClient! != null) await pkClient.stop();

--- a/src/nodes/CommandConnections.ts
+++ b/src/nodes/CommandConnections.ts
@@ -59,7 +59,7 @@ class CommandAdd extends CommandPolykey {
         }, auth);
         if (options.format === 'human') {
           // Wait for outputFormatter to complete and then write to stdout
-          const formattedOutput = await binUtils.outputFormatter({
+          const formattedOutput = binUtils.outputFormatter({
             type: 'table',
             data: connections,
             options: {
@@ -76,7 +76,7 @@ class CommandAdd extends CommandPolykey {
           process.stdout.write(formattedOutput);
         } else {
           // Wait for outputFormatter to complete and then write to stdout
-          const formattedOutput = await binUtils.outputFormatter({
+          const formattedOutput = binUtils.outputFormatter({
             type: 'json',
             data: connections,
           });

--- a/src/nodes/CommandConnections.ts
+++ b/src/nodes/CommandConnections.ts
@@ -63,7 +63,7 @@ class CommandAdd extends CommandPolykey {
             type: 'table',
             data: connections,
             options: {
-              headers: [
+              columns: [
                 'host',
                 'hostname',
                 'nodeIdEncoded',
@@ -71,6 +71,7 @@ class CommandAdd extends CommandPolykey {
                 'timeout',
                 'usageCount',
               ],
+              includeHeaders: true,
             },
           });
           process.stdout.write(formattedOutput);

--- a/src/nodes/CommandConnections.ts
+++ b/src/nodes/CommandConnections.ts
@@ -59,7 +59,7 @@ class CommandAdd extends CommandPolykey {
         }, auth);
         if (options.format === 'human') {
           // Wait for outputFormatter to complete and then write to stdout
-          const formattedOutput = binUtils.outputFormatter({
+          const outputFormatted = binUtils.outputFormatter({
             type: 'table',
             data: connections,
             options: {
@@ -74,14 +74,14 @@ class CommandAdd extends CommandPolykey {
               includeHeaders: true,
             },
           });
-          process.stdout.write(formattedOutput);
+          process.stdout.write(outputFormatted);
         } else {
           // Wait for outputFormatter to complete and then write to stdout
-          const formattedOutput = binUtils.outputFormatter({
+          const outputFormatted = binUtils.outputFormatter({
             type: 'json',
             data: connections,
           });
-          process.stdout.write(formattedOutput);
+          process.stdout.write(outputFormatted);
         }
       } finally {
         if (pkClient! != null) await pkClient.stop();

--- a/src/nodes/CommandFind.ts
+++ b/src/nodes/CommandFind.ts
@@ -90,7 +90,7 @@ class CommandFind extends CommandPolykey {
         }
         let output: any = result;
         if (options.format === 'human') output = [result.message];
-        const formattedOutput = await binUtils.outputFormatter({
+        const formattedOutput = binUtils.outputFormatter({
           type: options.format === 'json' ? 'json' : 'list',
           data: output,
         });

--- a/src/nodes/CommandFind.ts
+++ b/src/nodes/CommandFind.ts
@@ -90,11 +90,11 @@ class CommandFind extends CommandPolykey {
         }
         let output: any = result;
         if (options.format === 'human') output = [result.message];
-        const formattedOutput = binUtils.outputFormatter({
+        const outputFormatted = binUtils.outputFormatter({
           type: options.format === 'json' ? 'json' : 'list',
           data: output,
         });
-        process.stdout.write(formattedOutput);
+        process.stdout.write(outputFormatted);
         // Like ping it should error when failing to find node for automation reasons.
         if (!result.success) {
           throw new errors.ErrorPolykeyCLINodeFindFailed(result.message);

--- a/src/nodes/CommandGetAll.ts
+++ b/src/nodes/CommandGetAll.ts
@@ -60,7 +60,7 @@ class CommandGetAll extends CommandPolykey {
               `NodeId ${value.nodeIdEncoded}, Address ${value.host}:${value.port}, bucketIndex ${value.bucketIndex}`,
           );
         }
-        const formattedOutput = await binUtils.outputFormatter({
+        const formattedOutput = binUtils.outputFormatter({
           type: options.format === 'json' ? 'json' : 'list',
           data: output,
         });

--- a/src/nodes/CommandGetAll.ts
+++ b/src/nodes/CommandGetAll.ts
@@ -60,11 +60,11 @@ class CommandGetAll extends CommandPolykey {
               `NodeId ${value.nodeIdEncoded}, Address ${value.host}:${value.port}, bucketIndex ${value.bucketIndex}`,
           );
         }
-        const formattedOutput = binUtils.outputFormatter({
+        const outputFormatted = binUtils.outputFormatter({
           type: options.format === 'json' ? 'json' : 'list',
           data: output,
         });
-        process.stdout.write(formattedOutput);
+        process.stdout.write(outputFormatted);
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/nodes/CommandPing.ts
+++ b/src/nodes/CommandPing.ts
@@ -68,7 +68,7 @@ class CommandPing extends CommandPolykey {
         else status.message = error.message;
         const output: any =
           options.format === 'json' ? status : [status.message];
-        const formattedOutput = await binUtils.outputFormatter({
+        const formattedOutput = binUtils.outputFormatter({
           type: options.format === 'json' ? 'json' : 'list',
           data: output,
         });

--- a/src/nodes/CommandPing.ts
+++ b/src/nodes/CommandPing.ts
@@ -68,11 +68,11 @@ class CommandPing extends CommandPolykey {
         else status.message = error.message;
         const output: any =
           options.format === 'json' ? status : [status.message];
-        const formattedOutput = binUtils.outputFormatter({
+        const outputFormatted = binUtils.outputFormatter({
           type: options.format === 'json' ? 'json' : 'list',
           data: output,
         });
-        process.stdout.write(formattedOutput);
+        process.stdout.write(outputFormatted);
 
         if (error != null) throw error;
       } finally {

--- a/src/notifications/CommandRead.ts
+++ b/src/notifications/CommandRead.ts
@@ -79,11 +79,11 @@ class CommandRead extends CommandPolykey {
           notifications.push(notification);
         }
         for (const notification of notifications) {
-          const formattedOutput = binUtils.outputFormatter({
+          const outputFormatted = binUtils.outputFormatter({
             type: options.format === 'json' ? 'json' : 'dict',
             data: notification,
           });
-          process.stdout.write(formattedOutput);
+          process.stdout.write(outputFormatted);
         }
       } finally {
         if (pkClient! != null) await pkClient.stop();

--- a/src/notifications/CommandRead.ts
+++ b/src/notifications/CommandRead.ts
@@ -79,7 +79,7 @@ class CommandRead extends CommandPolykey {
           notifications.push(notification);
         }
         for (const notification of notifications) {
-          const formattedOutput = await binUtils.outputFormatter({
+          const formattedOutput = binUtils.outputFormatter({
             type: options.format === 'json' ? 'json' : 'dict',
             data: notification,
           });

--- a/src/secrets/CommandGet.ts
+++ b/src/secrets/CommandGet.ts
@@ -59,11 +59,11 @@ class CommandGet extends CommandPolykey {
           meta,
         );
         const secretContent = Buffer.from(response.secretContent, 'binary');
-        const formattedOutput = binUtils.outputFormatter({
+        const outputFormatted = binUtils.outputFormatter({
           type: 'raw',
           data: secretContent,
         });
-        process.stdout.write(formattedOutput);
+        process.stdout.write(outputFormatted);
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/secrets/CommandGet.ts
+++ b/src/secrets/CommandGet.ts
@@ -58,10 +58,12 @@ class CommandGet extends CommandPolykey {
             }),
           meta,
         );
-        const secretContent = Buffer.from(response.secretContent, 'binary');
+        const secretContent = response.secretContent;
         const outputFormatted = binUtils.outputFormatter({
           type: 'raw',
-          data: `"${binUtils.encodeQuotes(secretContent.toString('utf-8'))}"`, // Encodes any secret content with escape characters
+          data: binUtils.encodeEscapedWrapped(secretContent)
+            ? binUtils.encodeEscaped(secretContent)
+            : secretContent,
         });
         process.stdout.write(outputFormatted);
       } finally {

--- a/src/secrets/CommandGet.ts
+++ b/src/secrets/CommandGet.ts
@@ -61,7 +61,7 @@ class CommandGet extends CommandPolykey {
         const secretContent = Buffer.from(response.secretContent, 'binary');
         const outputFormatted = binUtils.outputFormatter({
           type: 'raw',
-          data: secretContent,
+          data: `"${binUtils.encodeQuotes(secretContent.toString('utf-8'))}"`, // Encodes any secret content with escape characters
         });
         process.stdout.write(outputFormatted);
       } finally {

--- a/src/secrets/CommandGet.ts
+++ b/src/secrets/CommandGet.ts
@@ -59,7 +59,7 @@ class CommandGet extends CommandPolykey {
           meta,
         );
         const secretContent = Buffer.from(response.secretContent, 'binary');
-        const formattedOutput = await binUtils.outputFormatter({
+        const formattedOutput = binUtils.outputFormatter({
           type: 'raw',
           data: secretContent,
         });

--- a/src/secrets/CommandList.ts
+++ b/src/secrets/CommandList.ts
@@ -57,7 +57,7 @@ class CommandList extends CommandPolykey {
           return data;
         }, auth);
 
-        const formattedOutput = await binUtils.outputFormatter({
+        const formattedOutput = binUtils.outputFormatter({
           type: options.format === 'json' ? 'json' : 'list',
           data: data,
         });

--- a/src/secrets/CommandList.ts
+++ b/src/secrets/CommandList.ts
@@ -57,12 +57,12 @@ class CommandList extends CommandPolykey {
           return data;
         }, auth);
 
-        const formattedOutput = binUtils.outputFormatter({
+        const outputFormatted = binUtils.outputFormatter({
           type: options.format === 'json' ? 'json' : 'list',
           data: data,
         });
 
-        process.stdout.write(formattedOutput);
+        process.stdout.write(outputFormatted);
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/secrets/CommandStat.ts
+++ b/src/secrets/CommandStat.ts
@@ -60,7 +60,7 @@ class CommandStat extends CommandPolykey {
           meta,
         );
 
-        const data: string[] = [`Stats for "${secretPath[1]}"`];
+        const data: Array<string> = [`Stats for "${secretPath[1]}"`];
         for (const [key, value] of Object.entries(response.stat)) {
           data.push(`${key}: ${value}`);
         }

--- a/src/secrets/CommandStat.ts
+++ b/src/secrets/CommandStat.ts
@@ -66,12 +66,12 @@ class CommandStat extends CommandPolykey {
         }
 
         // Assuming the surrounding function is async
-        const formattedOutput = binUtils.outputFormatter({
+        const outputFormatted = binUtils.outputFormatter({
           type: options.format === 'json' ? 'json' : 'list',
           data,
         });
 
-        process.stdout.write(formattedOutput);
+        process.stdout.write(outputFormatted);
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/secrets/CommandStat.ts
+++ b/src/secrets/CommandStat.ts
@@ -66,7 +66,7 @@ class CommandStat extends CommandPolykey {
         }
 
         // Assuming the surrounding function is async
-        const formattedOutput = await binUtils.outputFormatter({
+        const formattedOutput = binUtils.outputFormatter({
           type: options.format === 'json' ? 'json' : 'list',
           data,
         });

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,7 @@ type AgentChildProcessOutput =
 type TableRow = Record<string, any>;
 
 interface TableOptions {
-  headers?: string[];
+  headers?: Array<string>;
   includeRowCount?: boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,15 @@ import type { RecoveryCode } from 'polykey/dist/keys/types';
 import type { StatusLive } from 'polykey/dist/status/types';
 import type { NodeIdEncoded } from 'polykey/dist/ids/types';
 
+
+type TableRow = Record<string, any>;
+
+interface TableOptions {
+  columns?: Array<string> | Record<string, number>;
+  includeHeaders?: boolean;
+  includeRowCount?: boolean;
+}
+
 type AgentStatusLiveData = Omit<StatusLive['data'], 'nodeId'> & {
   nodeId: NodeIdEncoded;
 };
@@ -40,17 +49,10 @@ type AgentChildProcessOutput =
       error: POJO;
     };
 
-type TableRow = Record<string, any>;
-
-interface TableOptions {
-  headers?: Array<string>;
-  includeRowCount?: boolean;
-}
-
 export type {
+  TableRow,
+  TableOptions,
   AgentStatusLiveData,
   AgentChildProcessInput,
   AgentChildProcessOutput,
-  TableRow,
-  TableOptions,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,6 @@ import type { RecoveryCode } from 'polykey/dist/keys/types';
 import type { StatusLive } from 'polykey/dist/status/types';
 import type { NodeIdEncoded } from 'polykey/dist/ids/types';
 
-
 type TableRow = Record<string, any>;
 
 interface TableOptions {

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -98,8 +98,7 @@ const parseProviderId: (data: string) => ids.ProviderId =
 
 const parseIdentityId: (data: string) => ids.IdentityId =
   validateParserToArgParser(ids.parseIdentityId);
-
-const parseProviderIdList: (data: string) => ids.ProviderId[] =
+const parseProviderIdList: (data: string) => Array<ids.ProviderId> =
   validateParserToArgListParser(ids.parseProviderId);
 
 const parseGestaltAction: (data: string) => 'notify' | 'scan' | 'claim' =

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -97,17 +97,18 @@ function encodeNonPrintable(str: string) {
 
 /**
  * Function to handle the `table` output format.
+ *
  * @param rows
  * @param options
  * @param options.columns - Can either be an `Array<string>` or `Record<string, number>`.
  * If it is `Record<string, number>`, the `number` values will be used as the initial padding lengths.
  * The object is also mutated if any cells exceed the inital padding lengths.
- * This paramater can also be supplied to filter the columns that will be displayed.
+ * This parameter can also be supplied to filter the columns that will be displayed.
  * @param options.includeHeaders - Defaults to `True`
  * @param options.includeRowCount - Defaults to `False`.
  * @returns
  */
-function outputTableFormatter(
+function outputFormatterTable(
   rows: Array<TableRow>,
   options: TableOptions = {
     includeHeaders: true,
@@ -197,8 +198,9 @@ function outputTableFormatter(
 
 /**
  * Formats a message suitable for output.
+ *
  * @param msg - The msg that needs to be formatted.
- * @see {@link outputTableFormatter} for information regarding usage where `msg.type === 'table'`.
+ * @see {@link outputFormatterTable} for information regarding usage where `msg.type === 'table'`.
  * @returns
  */
 function outputFormatter(msg: OutputObject): string | Uint8Array {
@@ -211,7 +213,7 @@ function outputFormatter(msg: OutputObject): string | Uint8Array {
       output += `${elem != null ? encodeNonPrintable(elem) : ''}\n`;
     }
   } else if (msg.type === 'table') {
-    return outputTableFormatter(msg.data, msg.options);
+    return outputFormatterTable(msg.data, msg.options);
   } else if (msg.type === 'dict') {
     let maxKeyLength = 0;
     for (const key in msg.data) {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -70,7 +70,7 @@ function standardErrorReplacer(key: string, value: any) {
  * 2. Converts \n \r \t to escaped versions, \\n \\r and \\t.
  * 3. Converts other control characters to their Unicode escape sequences.
  */
-function encodeNonPrintable(str: string) {
+function encodeNonPrintable(str: string): string {
   // We want to actually match control codes here!
   // eslint-disable-next-line no-control-regex
   return str.replace(/[\x00-\x1F\x7F-\x9F]/g, (char) => {
@@ -102,20 +102,25 @@ function encodeNonPrintable(str: string) {
  * @see {@link outputFormatterTable} for information regarding usage where `msg.type === 'table'`.
  * @returns
  */
-function outputFormatter(msg: OutputObject): string | Uint8Array {
+function outputFormatter(msg: OutputObject): string {
+  let data = msg.data;
   switch (msg.type) {
     case 'raw':
-      return msg.data;
+      if (ArrayBuffer.isView(data)) {
+        const td = new TextDecoder('utf-8');
+        data = encodeNonPrintable(td.decode(data));
+      }
+      return data;
     case 'list':
-      return outputFormatterList(msg.data);
+      return outputFormatterList(data);
     case 'table':
-      return outputFormatterTable(msg.data, msg.options);
+      return outputFormatterTable(data, msg.options);
     case 'dict':
-      return outputFormatterDict(msg.data);
+      return outputFormatterDict(data);
     case 'json':
-      return outputFormatterJson(msg.data);
+      return outputFormatterJson(data);
     case 'error':
-      return outputFormatterError(msg.data);
+      return outputFormatterError(data);
   }
 }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -97,7 +97,7 @@ function encodeNonPrintable(str: string) {
 
 // Function to handle 'table' type output
 function outputTableFormatter(
-  rowStream: TableRow[],
+  rowStream: Array<TableRow>,
   options?: TableOptions,
 ): string {
   let output = '';

--- a/src/vaults/CommandCreate.ts
+++ b/src/vaults/CommandCreate.ts
@@ -54,7 +54,7 @@ class CommandCreate extends CommandPolykey {
             }),
           meta,
         );
-        const formattedOutput = await binUtils.outputFormatter({
+        const formattedOutput = binUtils.outputFormatter({
           type: options.format === 'json' ? 'json' : 'list',
           data: [`Vault ${response.vaultIdEncoded} created successfully`],
         });

--- a/src/vaults/CommandCreate.ts
+++ b/src/vaults/CommandCreate.ts
@@ -54,11 +54,11 @@ class CommandCreate extends CommandPolykey {
             }),
           meta,
         );
-        const formattedOutput = binUtils.outputFormatter({
+        const outputFormatted = binUtils.outputFormatter({
           type: options.format === 'json' ? 'json' : 'list',
           data: [`Vault ${response.vaultIdEncoded} created successfully`],
         });
-        process.stdout.write(formattedOutput);
+        process.stdout.write(outputFormatted);
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/vaults/CommandList.ts
+++ b/src/vaults/CommandList.ts
@@ -51,7 +51,9 @@ class CommandList extends CommandPolykey {
           });
           for await (const vaultListMessage of stream) {
             data.push(
-              `${vaultListMessage.vaultName}:\t\t${vaultListMessage.vaultIdEncoded}`,
+              `${vaultListMessage.vaultName}:${' '.repeat(4)}${
+                vaultListMessage.vaultIdEncoded
+              }`,
             );
           }
           return data;

--- a/src/vaults/CommandList.ts
+++ b/src/vaults/CommandList.ts
@@ -56,7 +56,7 @@ class CommandList extends CommandPolykey {
           }
           return data;
         }, meta);
-        const formattedOutput = await binUtils.outputFormatter({
+        const formattedOutput = binUtils.outputFormatter({
           type: options.format === 'json' ? 'json' : 'list',
           data: data,
         });

--- a/src/vaults/CommandList.ts
+++ b/src/vaults/CommandList.ts
@@ -56,11 +56,11 @@ class CommandList extends CommandPolykey {
           }
           return data;
         }, meta);
-        const formattedOutput = binUtils.outputFormatter({
+        const outputFormatted = binUtils.outputFormatter({
           type: options.format === 'json' ? 'json' : 'list',
           data: data,
         });
-        process.stdout.write(formattedOutput);
+        process.stdout.write(outputFormatted);
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/vaults/CommandLog.ts
+++ b/src/vaults/CommandLog.ts
@@ -63,7 +63,7 @@ class CommandLog extends CommandPolykey {
           }
           return data;
         }, meta);
-        const formattedOutput = await binUtils.outputFormatter({
+        const formattedOutput = binUtils.outputFormatter({
           type: options.format === 'json' ? 'json' : 'list',
           data: data,
         });

--- a/src/vaults/CommandLog.ts
+++ b/src/vaults/CommandLog.ts
@@ -63,11 +63,11 @@ class CommandLog extends CommandPolykey {
           }
           return data;
         }, meta);
-        const formattedOutput = binUtils.outputFormatter({
+        const outputFormatted = binUtils.outputFormatter({
           type: options.format === 'json' ? 'json' : 'list',
           data: data,
         });
-        process.stdout.write(formattedOutput);
+        process.stdout.write(outputFormatted);
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/vaults/CommandPermissions.ts
+++ b/src/vaults/CommandPermissions.ts
@@ -61,11 +61,11 @@ class CommandPermissions extends CommandPolykey {
         }, meta);
 
         if (data.length === 0) data.push('No permissions were found');
-        const formattedOutput = binUtils.outputFormatter({
+        const outputFormatted = binUtils.outputFormatter({
           type: options.format === 'json' ? 'json' : 'list',
           data: data,
         });
-        process.stdout.write(formattedOutput);
+        process.stdout.write(outputFormatted);
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/vaults/CommandPermissions.ts
+++ b/src/vaults/CommandPermissions.ts
@@ -61,7 +61,7 @@ class CommandPermissions extends CommandPolykey {
         }, meta);
 
         if (data.length === 0) data.push('No permissions were found');
-        const formattedOutput = await binUtils.outputFormatter({
+        const formattedOutput = binUtils.outputFormatter({
           type: options.format === 'json' ? 'json' : 'list',
           data: data,
         });

--- a/src/vaults/CommandScan.ts
+++ b/src/vaults/CommandScan.ts
@@ -56,7 +56,7 @@ class CommandScan extends CommandPolykey {
             const permissions = vault.permissions.join(',');
             data.push(
               `${vaultName}${' '.repeat(4)}${vaultIdEncoded}${' '.repeat(
-                5,
+                4,
               )}${permissions}`,
             );
           }

--- a/src/vaults/CommandScan.ts
+++ b/src/vaults/CommandScan.ts
@@ -58,11 +58,11 @@ class CommandScan extends CommandPolykey {
           }
           return data;
         }, meta);
-        const formattedOutput = binUtils.outputFormatter({
+        const outputFormatted = binUtils.outputFormatter({
           type: options.format === 'json' ? 'json' : 'list',
           data: data,
         });
-        process.stdout.write(formattedOutput);
+        process.stdout.write(outputFormatted);
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/vaults/CommandScan.ts
+++ b/src/vaults/CommandScan.ts
@@ -54,7 +54,11 @@ class CommandScan extends CommandPolykey {
             const vaultName = vault.vaultName;
             const vaultIdEncoded = vault.vaultIdEncoded;
             const permissions = vault.permissions.join(',');
-            data.push(`${vaultName}\t\t${vaultIdEncoded}\t\t${permissions}`);
+            data.push(
+              `${vaultName}${' '.repeat(4)}${vaultIdEncoded}${' '.repeat(
+                5,
+              )}${permissions}`,
+            );
           }
           return data;
         }, meta);

--- a/src/vaults/CommandScan.ts
+++ b/src/vaults/CommandScan.ts
@@ -58,7 +58,7 @@ class CommandScan extends CommandPolykey {
           }
           return data;
         }, meta);
-        const formattedOutput = await binUtils.outputFormatter({
+        const formattedOutput = binUtils.outputFormatter({
           type: options.format === 'json' ? 'json' : 'list',
           data: data,
         });

--- a/tests/keys/cert.test.ts
+++ b/tests/keys/cert.test.ts
@@ -16,7 +16,7 @@ describe('cert', () => {
   testUtils.testIf(
     testUtils.isTestPlatformEmpty || testUtils.isTestPlatformDocker,
   )('cert gets the certificate', async () => {
-    let { exitCode, stdout } = await testUtils.pkExec(
+    const { exitCode, stdout } = await testUtils.pkExec(
       ['keys', 'cert', '--format', 'json'],
       {
         env: {
@@ -31,20 +31,5 @@ describe('cert', () => {
     expect(JSON.parse(stdout)).toEqual({
       cert: expect.any(String),
     });
-    const certCommand = JSON.parse(stdout).cert;
-    ({ exitCode, stdout } = await testUtils.pkExec(
-      ['keys', 'cert', '--format', 'json'],
-      {
-        env: {
-          PK_NODE_PATH: agentDir,
-          PK_PASSWORD: agentPassword,
-        },
-        cwd: agentDir,
-        command: globalThis.testCmd,
-      },
-    ));
-    expect(exitCode).toBe(0);
-    const certStatus = JSON.parse(stdout).cert;
-    expect(certCommand).toBe(certStatus);
   });
 });

--- a/tests/keys/certchain.test.ts
+++ b/tests/keys/certchain.test.ts
@@ -18,7 +18,7 @@ describe('certchain', () => {
   testUtils.testIf(
     testUtils.isTestPlatformEmpty || testUtils.isTestPlatformDocker,
   )('certchain gets the certificate chain', async () => {
-    let { exitCode, stdout } = await testUtils.pkExec(
+    const { exitCode, stdout } = await testUtils.pkExec(
       ['keys', 'certchain', '--format', 'json'],
       {
         env: {
@@ -33,20 +33,5 @@ describe('certchain', () => {
     expect(JSON.parse(stdout)).toEqual({
       certchain: expect.any(Array),
     });
-    const certChainCommand = JSON.parse(stdout).certchain.join('\n');
-    ({ exitCode, stdout } = await testUtils.pkExec(
-      ['agent', 'status', '--format', 'json'],
-      {
-        env: {
-          PK_NODE_PATH: agentDir,
-          PK_PASSWORD: agentPassword,
-        },
-        cwd: agentDir,
-        command: globalThis.testCmd,
-      },
-    ));
-    expect(exitCode).toBe(0);
-    const certChainStatus = JSON.parse(stdout).rootCertChainPem;
-    expect(certChainCommand.rootPublicKeyPem).toBe(certChainStatus);
   });
 });

--- a/tests/nodes/connections.test.ts
+++ b/tests/nodes/connections.test.ts
@@ -31,8 +31,8 @@ describe('connections', () => {
         nodePath,
         agentServiceHost: '127.0.0.1',
         clientServiceHost: '127.0.0.1',
-        agentServicePort: 55555,
-        clientServicePort: 55554,
+        agentServicePort: 0,
+        clientServicePort: 0,
         keys: {
           passwordOpsLimit: keysUtils.passwordOpsLimits.min,
           passwordMemLimit: keysUtils.passwordMemLimits.min,
@@ -50,8 +50,8 @@ describe('connections', () => {
         nodePath: path.join(dataDir, 'remoteNode'),
         agentServiceHost: '127.0.0.1',
         clientServiceHost: '127.0.0.1',
-        agentServicePort: 55553,
-        clientServicePort: 55552,
+        agentServicePort: 0,
+        clientServicePort: 0,
         keys: {
           passwordOpsLimit: keysUtils.passwordOpsLimits.min,
           passwordMemLimit: keysUtils.passwordMemLimits.min,

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -52,7 +52,9 @@ describe('bin/utils', () => {
           includeHeaders: true,
         },
       });
-      expect(tableOutput).toBe('value1\tvalue2\ndata1 \tdata2\nN/A   \tN/A\n');
+      expect(tableOutput).toBe(
+        '"value1"\t"value2"\n"data1" \t"data2"\nN/A     \tN/A\n',
+      );
 
       // JSON
       const jsonOutput = binUtils.outputFormatter({
@@ -72,7 +74,7 @@ describe('bin/utils', () => {
     async () => {
       let tableOutput = '';
       const keys = {
-        key1: 7,
+        key1: 10,
         key2: 4,
       };
       const generator = function* () {
@@ -93,11 +95,11 @@ describe('bin/utils', () => {
         i++;
       }
       expect(keys).toStrictEqual({
-        key1: 7,
-        key2: 6,
+        key1: 10,
+        key2: 8,
       });
       expect(tableOutput).toBe(
-        'key1   \tkey2  \nvalue1 \tvalue2\ndata1  \tdata2\nN/A    \tN/A\n',
+        'key1      \tkey2    \n"value1"  \t"value2"\n"data1"   \t"data2"\nN/A       \tN/A\n',
       );
     },
   );
@@ -146,17 +148,17 @@ describe('bin/utils', () => {
             });
 
             // Construct the expected output
-            let expectedValue = JSON.stringify(value);
+            let expectedValue = binUtils.encodeQuotes(value);
             expectedValue = binUtils.encodeNonPrintable(expectedValue);
             expectedValue = expectedValue.replace(/(?:\r\n|\n)$/, '');
             expectedValue = expectedValue.replace(/(\r\n|\n)/g, '$1\t');
+            expectedValue = `"${expectedValue}"`;
 
             const maxKeyLength = Math.max(
               ...Object.keys({ [key]: value }).map((k) => k.length),
             );
             const padding = ' '.repeat(maxKeyLength - key.length);
             const expectedOutput = `${key}${padding}\t${expectedValue}\n`;
-
             // Assert that the formatted output matches the expected output
             expect(formattedOutput).toBe(expectedOutput);
           },
@@ -277,6 +279,14 @@ describe('bin/utils', () => {
           binUtils.standardErrorReplacer,
         ) + '\n',
       );
+    },
+  );
+  testUtils.testIf(testUtils.isTestPlatformEmpty)(
+    'encoding non-printable strings works',
+    () => {
+      expect(binUtils.encodeWrappedStrings('\n"\n"')).toBe('\n"\\n"');
+      expect(binUtils.encodeWrappedStrings('"\\""')).toBe('"\\""');
+      expect(binUtils.encodeWrappedStrings('"\\"\n\\""')).toBe('"\\"\\n\\""');
     },
   );
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -48,6 +48,9 @@ describe('bin/utils', () => {
           { key1: 'data1', key2: 'data2' },
           { key1: null, key2: undefined },
         ],
+        options: {
+          includeHeaders: true,
+        },
       });
       expect(tableOutput).toBe('value1\tvalue2\ndata1 \tdata2\nN/A   \tN/A\n');
 
@@ -61,6 +64,40 @@ describe('bin/utils', () => {
       });
       expect(jsonOutput).toBe(
         '[{"key1":"value1","key2":"value2"},{"key1":"data1","key2":"data2"}]\n',
+      );
+    },
+  );
+  testUtils.testIf(testUtils.isTestPlatformEmpty)(
+    'table in human format for streaming usage',
+    async () => {
+      let tableOutput = '';
+      const keys = {
+        key1: 7,
+        key2: 4,
+      };
+      const generator = function* () {
+        yield [{ key1: 'value1', key2: 'value2' }];
+        yield [{ key1: 'data1', key2: 'data2' }];
+        yield [{ key1: null, key2: undefined }];
+      };
+      let i = 0;
+      for (const data of generator()) {
+        tableOutput += binUtils.outputFormatter({
+          type: 'table',
+          data: data,
+          options: {
+            columns: keys,
+            includeHeaders: i === 0,
+          },
+        });
+        i++;
+      }
+      expect(keys).toStrictEqual({
+        key1: 7,
+        key2: 6,
+      });
+      expect(tableOutput).toBe(
+        'key1   \tkey2  \nvalue1 \tvalue2\ndata1  \tdata2\nN/A    \tN/A\n',
       );
     },
   );

--- a/tests/vaults/vaults.test.ts
+++ b/tests/vaults/vaults.test.ts
@@ -907,11 +907,13 @@ describe('CLI vaults', () => {
             cwd: dataDir,
           });
           expect(result3.exitCode).toBe(0);
+          expect(result3.stdout).toMatch(/Vault1\\t\\t.*\\t\\tclone/);
           expect(result3.stdout).toContain(
-            `Vault1\t\t${vaultsUtils.encodeVaultId(vault1Id)}\t\tclone`,
-          );
-          expect(result3.stdout).toContain(
-            `Vault2\t\t${vaultsUtils.encodeVaultId(vault2Id)}\t\tpull,clone`,
+            `Vault1\\t\\t${vaultsUtils.encodeVaultId(
+              vault1Id,
+            )}\\t\\tclone\nVault2\\t\\t${vaultsUtils.encodeVaultId(
+              vault2Id,
+            )}\\t\\tpull,clone\n`,
           );
           expect(result3.stdout).not.toContain(
             `Vault3\t\t${vaultsUtils.encodeVaultId(vault3Id)}`,

--- a/tests/vaults/vaults.test.ts
+++ b/tests/vaults/vaults.test.ts
@@ -907,16 +907,18 @@ describe('CLI vaults', () => {
             cwd: dataDir,
           });
           expect(result3.exitCode).toBe(0);
-          expect(result3.stdout).toMatch(/Vault1\\t\\t.*\\t\\tclone/);
+          expect(result3.stdout).toMatch(/Vault1 {4}.* {4}clone/);
           expect(result3.stdout).toContain(
-            `Vault1\\t\\t${vaultsUtils.encodeVaultId(
+            `Vault1${' '.repeat(4)}${vaultsUtils.encodeVaultId(
               vault1Id,
-            )}\\t\\tclone\nVault2\\t\\t${vaultsUtils.encodeVaultId(
-              vault2Id,
-            )}\\t\\tpull,clone\n`,
+            )}${' '.repeat(4)}clone\nVault2${' '.repeat(
+              4,
+            )}${vaultsUtils.encodeVaultId(vault2Id)}${' '.repeat(
+              4,
+            )}pull,clone\n`,
           );
           expect(result3.stdout).not.toContain(
-            `Vault3\t\t${vaultsUtils.encodeVaultId(vault3Id)}`,
+            `Vault3${' '.repeat(4)}${vaultsUtils.encodeVaultId(vault3Id)}`,
           );
         } finally {
           await remoteOnline?.stop();


### PR DESCRIPTION
### Description

This PR builds upon https://github.com/MatrixAI/Polykey-CLI/pull/45

And aims to fix some issues which were not resolved in their entirety in #45. 

#### Automatic Encoding

For these two formats, encoding is applied by default so that special characters will not mess up the padding for any given output.
- dict format
  - will automatically encase any string in a `\"\"` and apply encoding to the input
- table format
  - will automatically encase any string in a `\"\"` and apply encoding to the input

#### Manual Encoding with Utility Functions

For any other format passed into `outputFormatter`, there will be no encoding of escapable characters by default.

It is up to the user to use the following functions in `src/utils/utils.ts` to encode parts of their input:

```ts
/**
 * This function:
 *
 * 1. Keeps regular spaces, only ' ', as they are.
 * 2. Converts \\n \\r \\t to escaped versions, \\\\n \\\\r and \\\\t.
 * 3. Converts other control characters to their Unicode escape sequences.\
 * 4. Converts ' \` " to escaped versions, \\\\' \\\\\` and \\\\"
 *
 * Unless you're using this in a `JSON.stringify` replacer, you probably want to use {@link encodeEscapedWrapped} instead.
 */
function encodeEscaped(str: string): string
```

```ts
/**
 * This function:
 * 1. Keeps regular spaces, only ' ', as they are.
 * 2. Converts \\n \\r \\t to escaped versions, \\\\n \\\\r and \\\\t.
 * 3. Converts other control characters to their Unicode escape sequences.
 * 4. Converts ' \` " to escaped versions, \\\\' \\\\\` and \\\\"
 * 5. Wraps the whole thing in `""` if any characters have been encoded.
 */
function encodeEscapedWrapped(str: string): string
```

To use this:

```ts
const v = `test ${encodeEscapedWrapped("\u0000\"\n")}` // returns '"\\u0000\\"\\n"'
```

Note that any encoded strings must be encased in `""` anyways. This is so that when the user copy-pastes the output as the input of another command, or pipes the output to another command, those escaped characters will be collapsed correctly

These mainly include:

1. Simplification of outputTableFormatter.
2. Adding quotes back on stdout.
3. Encode non-printable characters except spaces.

### Tasks

- [x] 1. Tidy up outputTableFormatter.
- [x] 2. Adding double quotes back on STDOUT.
- [x] 3. Encoding non-printable chars except spaces on STDOUT.
- [x] 4. Define and implement new `encodeEscaped` and `encodeEscapedWrapped` API for output character escape encoding

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
