### PR TITLE
nodes status should include connection and graph stats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "nexpect": "^0.6.0",
         "node-gyp-build": "^4.4.0",
         "nodemon": "^3.0.1",
-        "polykey": "^1.2.1-alpha.27",
+        "polykey": "^1.2.1-alpha.29",
         "prettier": "^3.0.0",
         "shelljs": "^0.8.5",
         "shx": "^0.3.4",
@@ -7469,9 +7469,9 @@
       }
     },
     "node_modules/polykey": {
-      "version": "1.2.1-alpha.27",
-      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.2.1-alpha.27.tgz",
-      "integrity": "sha512-LUNKgvgNZH4cIl/egJj/LgIqPYhlN8zAhNlhPAyRg/zUMJeeeR7noevje/c+OJ4oXx0PjRvgV8ljJ710mAcGSA==",
+      "version": "1.2.1-alpha.29",
+      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.2.1-alpha.29.tgz",
+      "integrity": "sha512-bAsJEVtey2xxlDbHBufmLtpjVvHKwkkrxuGtAB6YOhR5hIDkJb+9Qu+SrE6El2uqBsSqwge37AA+8e6y9H66fw==",
       "dev": true,
       "dependencies": {
         "@matrixai/async-cancellable": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@matrixai/errors": "^1.2.0",
     "@matrixai/logger": "^3.1.0",
     "commander": "^8.3.0",
-    "polykey": "^1.2.1-alpha.27",
+    "polykey": "^1.2.1-alpha.29",
     "threads": "^1.6.5",
     "@swc/core": "1.3.82",
     "@swc/jest": "^0.2.29",

--- a/src/agent/CommandStatus.ts
+++ b/src/agent/CommandStatus.ts
@@ -17,6 +17,7 @@ class CommandStatus extends CommandPolykey {
       const { default: PolykeyClient } = await import(
         'polykey/dist/PolykeyClient'
       );
+      const { getUnixtime } = await import('polykey/dist/utils/utils');
       const clientStatus = await binProcessors.processClientStatus(
         options.nodePath,
         options.nodeId,
@@ -79,6 +80,9 @@ class CommandStatus extends CommandPolykey {
               clientPort: response.clientPort,
               agentHost: response.agentHost,
               agentPort: response.agentPort,
+              upTime: getUnixtime() - response.startTime,
+              connectionsActive: response.connectionsActive,
+              nodesTotal: response.nodesTotal,
             },
           }),
         );

--- a/tests/agent/status.test.ts
+++ b/tests/agent/status.test.ts
@@ -179,6 +179,9 @@ describe('status', () => {
         clientPort: statusInfo.data.clientPort,
         agentHost: statusInfo.data.agentHost,
         agentPort: statusInfo.data.agentPort,
+        upTime: expect.any(Number),
+        connectionsActive: expect.any(Number),
+        nodesTotal: expect.any(Number),
       });
     });
     testUtils.testIf(
@@ -227,6 +230,9 @@ describe('status', () => {
         clientPort: statusInfo.data.clientPort,
         agentHost: statusInfo.data.agentHost,
         agentPort: statusInfo.data.agentPort,
+        upTime: expect.any(Number),
+        connectionsActive: expect.any(Number),
+        nodesTotal: expect.any(Number),
       });
     });
   });


### PR DESCRIPTION
### Description

Needs a rebase after merge of #45

Currently, `nodes status` lacks a lot of vital information, this PR aims to add some extra information to `nodes status` to make it more informational.

Currently, we have added 

* Number of active connections.
* Total nodes created.

### Issues Fixed

* Fixes #36

### Tasks

- [x] 1. Implement active connections.
- [x] 2. Implement total nodes.
- ~3. Implement node graph information other than total nodes.~ 

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
