### PR TITLE
Local Discovery Support with MDNS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "nexpect": "^0.6.0",
         "node-gyp-build": "^4.4.0",
         "nodemon": "^3.0.1",
-        "polykey": "^1.2.1-alpha.19",
+        "polykey": "^1.2.1-alpha.25",
         "prettier": "^3.0.0",
         "shelljs": "^0.8.5",
         "shx": "^0.3.4",
@@ -1431,15 +1431,41 @@
       }
     },
     "node_modules/@matrixai/logger": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@matrixai/logger/-/logger-3.1.0.tgz",
-      "integrity": "sha512-C4JWpgbNik3V99bfGfDell5cH3JULD67eEq9CeXl4rYgsvanF8hhuY84ZYvndPhimt9qjA9/Z8uExKGoiv1zVw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@matrixai/logger/-/logger-3.1.2.tgz",
+      "integrity": "sha512-nNliLCnbg6hGS2+gGtQfeeyVNJzOmvqz90AbrQsHPNiE08l3YsENL2JQt9d454SorD1Ud51ymZdDCkeMLWY93A==",
       "devOptional": true
     },
+    "node_modules/@matrixai/mdns": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@matrixai/mdns/-/mdns-1.2.3.tgz",
+      "integrity": "sha512-CcnIVWb3TjNRbrmFOEoY5rsUM7D7I5MeRGalaKXzCkhGwDKePXWiI8iQEs01Sp4/e4vxidNpjOEUgpRM8azxrw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@matrixai/async-cancellable": "^1.1.1",
+        "@matrixai/async-init": "^1.10.0",
+        "@matrixai/contexts": "^1.1.0",
+        "@matrixai/errors": "^1.1.7",
+        "@matrixai/events": "^3.2.0",
+        "@matrixai/logger": "^3.1.0",
+        "@matrixai/table": "^1.2.0",
+        "@matrixai/timer": "^1.1.1",
+        "canonicalize": "^2.0.0",
+        "ip-num": "^1.5.1"
+      },
+      "engines": {
+        "msvs": "2019",
+        "node": "^20.5.1"
+      },
+      "optionalDependencies": {
+        "@matrixai/mdns-linux-x64": "1.2.3"
+      }
+    },
     "node_modules/@matrixai/mdns-linux-x64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@matrixai/mdns-linux-x64/-/mdns-linux-x64-1.1.5.tgz",
-      "integrity": "sha512-YC+a27rgmmka+lNLlEROxonAQTlKaU+kTjo7rkzkABnn3rcLsAiJCJj1r/ZzSYwzx5gDu8Xdr0K7pvcRDBiSqw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@matrixai/mdns-linux-x64/-/mdns-linux-x64-1.2.3.tgz",
+      "integrity": "sha512-/mt5JO0oWItS8ULJFMJhH8KpcUbT4WEsFq8HdSmsqMULzPCrjRqLREBPWYfcOhulnsw6Rb6kyPk7XmJcT1BOEQ==",
       "cpu": [
         "x64"
       ],
@@ -1449,9 +1475,9 @@
       ]
     },
     "node_modules/@matrixai/quic": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic/-/quic-1.0.0.tgz",
-      "integrity": "sha512-sJ+tnXHgngsTIH+AQrPxWeCw1IpbcXFdzhKNVQLPlvkCGPkkvGTUddCddpyqunN72dcQdLQDG6aFQG3bhrItsw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic/-/quic-1.1.1.tgz",
+      "integrity": "sha512-C3CizeW/0lQ+tu+J9sKB7Sl7vx4CJq1t875B5Y5C5Ao0cZcjK1Xi10lSRILcce1RdoCpUGlbVFosat7YdONiGg==",
       "dev": true,
       "dependencies": {
         "@matrixai/async-cancellable": "^1.1.1",
@@ -1466,16 +1492,16 @@
         "ip-num": "^1.5.0"
       },
       "optionalDependencies": {
-        "@matrixai/quic-darwin-arm64": "1.0.0",
-        "@matrixai/quic-darwin-x64": "1.0.0",
-        "@matrixai/quic-linux-x64": "1.0.0",
-        "@matrixai/quic-win32-x64": "1.0.0"
+        "@matrixai/quic-darwin-arm64": "1.1.1",
+        "@matrixai/quic-darwin-x64": "1.1.1",
+        "@matrixai/quic-linux-x64": "1.1.1",
+        "@matrixai/quic-win32-x64": "1.1.1"
       }
     },
     "node_modules/@matrixai/quic-darwin-arm64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-arm64/-/quic-darwin-arm64-1.0.0.tgz",
-      "integrity": "sha512-b6QW5PNNSFArnTQZJI6qLD4mi1w9/9Hfba+yc1gP3xdIuIFdwib+kM7YbnNIgG4WGsQ0bhk42tOmOqr68Ql2qQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-arm64/-/quic-darwin-arm64-1.1.1.tgz",
+      "integrity": "sha512-tTtJ1ppYzanlZLXnIBcyHPf+yzVCmn3CJHnA5ymMOJBfGN1zB6+ZPbuEWql/4+DveBn0qTMgbWzWGhv4xpi3Kg==",
       "cpu": [
         "arm64"
       ],
@@ -1485,9 +1511,9 @@
       ]
     },
     "node_modules/@matrixai/quic-darwin-x64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-x64/-/quic-darwin-x64-1.0.0.tgz",
-      "integrity": "sha512-GQXBsNV07gztUsGSktD225eYtpdraVu4ysO5oFDnKMMlp6irP3tdmbHFDHrG6zBuChFJwg/RGd91EWFmGl0byQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-x64/-/quic-darwin-x64-1.1.1.tgz",
+      "integrity": "sha512-XBhAO/fdY44s78zqhTwtUit5IU6ewZ3IZAbmKXDXQCpUQwJEORd9BV6kLfS+apiB8FGNgmaCsUoO8DoUMXr1eA==",
       "cpu": [
         "x64"
       ],
@@ -1497,9 +1523,9 @@
       ]
     },
     "node_modules/@matrixai/quic-linux-x64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-linux-x64/-/quic-linux-x64-1.0.0.tgz",
-      "integrity": "sha512-nADXVULD9jn7qaMo+9ftL6izpSYSM3wW/vcgKXTr4YCI1E/CsKPTrI8esanKbPfdnJ7ELlIRA9QddDgAEyWwQQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-linux-x64/-/quic-linux-x64-1.1.1.tgz",
+      "integrity": "sha512-EOT9u53Sw0NW6pesSYXO0KFdsh0sMXmrUr+9ZrlqlIIKRylPEUcvGgL5d1QTyMtNnwXoCl2azSkmX1QYg4tHFw==",
       "cpu": [
         "x64"
       ],
@@ -1509,9 +1535,9 @@
       ]
     },
     "node_modules/@matrixai/quic-win32-x64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-win32-x64/-/quic-win32-x64-1.0.0.tgz",
-      "integrity": "sha512-uRtMw3VjFGpyOEFDsHuLJu7lzZSMUhpXZalINA2uVOzWDHjKu0vd35W/J/SxhSAhiaBeeYIPj59exSFGQW43uA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-win32-x64/-/quic-win32-x64-1.1.1.tgz",
+      "integrity": "sha512-czHsmQ5YfYR2QXx4GxHaT9KveeeAnivHu3uUd+4KxKlTHBN8XM36X4y7ZuNxGvJjhhitidJ88NwxTQWe54hZGg==",
       "cpu": [
         "x64"
       ],
@@ -1527,9 +1553,9 @@
       "devOptional": true
     },
     "node_modules/@matrixai/rpc": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@matrixai/rpc/-/rpc-0.2.4.tgz",
-      "integrity": "sha512-OvIjAE00aYuufyeMbpMD+QXMAqrLVHNHMOU8kEGTiOg4fKoPi95/taD4jNvRsPFtvxY3SsHaRfkI9zN6Lf6iUA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/rpc/-/rpc-0.4.1.tgz",
+      "integrity": "sha512-DF5hxdE8riMdlBgV2o+a7lEPA3uPwQTrKf9B9yOPJBEr6tfkNALTBzc/kvsedRPQeOcPYPZpmEOtyNhRtRAGcg==",
       "dev": true,
       "dependencies": {
         "@matrixai/async-init": "^1.9.4",
@@ -1541,10 +1567,19 @@
         "ix": "^5.0.0"
       }
     },
+    "node_modules/@matrixai/table": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@matrixai/table/-/table-1.2.0.tgz",
+      "integrity": "sha512-vMj9YygnigmtBVgbzhKQdchtRuPqGL6vutqRGTC0tcZKHYiNh08N6AGQMXoIUe+iYP9A1WNYg2M3LXZZ54xvGg==",
+      "dev": true,
+      "dependencies": {
+        "resource-counter": "^1.2.4"
+      }
+    },
     "node_modules/@matrixai/timer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@matrixai/timer/-/timer-1.1.1.tgz",
-      "integrity": "sha512-8UKDoGuwKC6BvrY/yANJVH29v71wgQKH/tJlxMPohGxmzVUQO5+JeI4lUYVHTs2vq1AyKAWloF5fOig+I1dyGA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@matrixai/timer/-/timer-1.1.3.tgz",
+      "integrity": "sha512-BG5bAZMIt7qxc9iqAOCk2zm7V0+yNQLwp+WhsWVkP25Nvd1klqKpScE1lGwoLA27ygxEi+8IRU3wa8PLrhs0DQ==",
       "devOptional": true,
       "dependencies": {
         "@matrixai/async-cancellable": "^1.1.1",
@@ -3079,6 +3114,12 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canonicalize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.0.0.tgz",
+      "integrity": "sha512-ulDEYPv7asdKvqahuAY35c1selLdzDwHqugK92hfkzvlDCwXRRelDkR+Er33md/PtnpqHemgkuDPanZ4fiYZ8w==",
+      "dev": true
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -7429,9 +7470,9 @@
       }
     },
     "node_modules/polykey": {
-      "version": "1.2.1-alpha.19",
-      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.2.1-alpha.19.tgz",
-      "integrity": "sha512-V2NrX+juze5aAKZ5s43pVBmBr4qZmRPUSIPUa4kpW1xME8Snl+QMTOTn6j0UXovnZ0xxXsvl65ZDmSTIa4iKog==",
+      "version": "1.2.1-alpha.25",
+      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.2.1-alpha.25.tgz",
+      "integrity": "sha512-6/uexoPXKyjVPwomoGT9CpZaee06ZATb0qKXT7nIqGZ5f+GVYX67cQJOXjd4M1zth6JtQxOoXzjsBxTAQ+tltQ==",
       "dev": true,
       "dependencies": {
         "@matrixai/async-cancellable": "^1.1.1",
@@ -7442,11 +7483,12 @@
         "@matrixai/errors": "^1.2.0",
         "@matrixai/events": "^3.2.3",
         "@matrixai/id": "^3.3.6",
-        "@matrixai/logger": "^3.1.0",
-        "@matrixai/quic": "^1.0.0",
+        "@matrixai/logger": "^3.1.2",
+        "@matrixai/mdns": "^1.2.3",
+        "@matrixai/quic": "^1.1.1",
         "@matrixai/resources": "^1.1.5",
-        "@matrixai/rpc": "^0.2.4",
-        "@matrixai/timer": "^1.1.1",
+        "@matrixai/rpc": "^0.4.1",
+        "@matrixai/timer": "^1.1.3",
         "@matrixai/workers": "^1.3.7",
         "@matrixai/ws": "^1.1.7",
         "@peculiar/asn1-pkcs8": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@matrixai/errors": "^1.2.0",
     "@matrixai/logger": "^3.1.0",
     "commander": "^8.3.0",
-    "polykey": "^1.2.1-alpha.19",
+    "polykey": "^1.2.1-alpha.25",
     "threads": "^1.6.5",
     "@swc/core": "1.3.82",
     "@swc/jest": "^0.2.29",

--- a/tests/agent/start.test.ts
+++ b/tests/agent/start.test.ts
@@ -930,6 +930,7 @@ describe('start', () => {
                 [seedNodeId2]: {
                   host: seedNodeHost2 as Host,
                   port: seedNodePort2 as Port,
+                  scopes: ['global'],
                 },
               },
               testnet: {},
@@ -998,6 +999,7 @@ describe('start', () => {
                 [seedNodeId2]: {
                   host: seedNodeHost2 as Host,
                   port: seedNodePort2 as Port,
+                  scopes: ['global'],
                 },
               },
             });

--- a/tests/nodes/add.test.ts
+++ b/tests/nodes/add.test.ts
@@ -147,7 +147,11 @@ describe('add', () => {
       expect(exitCode).toBe(0);
       // Checking if node was added.
       const node = await pkAgent.nodeGraph.getNode(validNodeId);
-      expect(node?.address).toEqual({ host: validHost, port: port });
+      expect(node?.address).toEqual({
+        host: validHost,
+        port: port,
+        scopes: ['global'],
+      });
     },
   );
   testUtils.testIf(testUtils.isTestPlatformEmpty)(
@@ -197,7 +201,11 @@ describe('add', () => {
       expect(exitCode).toBe(0);
       // Checking if node was added.
       const node = await pkAgent.nodeGraph.getNode(validNodeId);
-      expect(node?.address).toEqual({ host: validHost, port: port });
+      expect(node?.address).toEqual({
+        host: validHost,
+        port: port,
+        scopes: ['global'],
+      });
     },
   );
 });

--- a/tests/nodes/find.test.ts
+++ b/tests/nodes/find.test.ts
@@ -116,13 +116,24 @@ describe('find', () => {
         },
       );
       expect(exitCode).toBe(0);
-      expect(JSON.parse(stdout)).toEqual({
+      const output = JSON.parse(stdout);
+      expect(output).toMatchObject({
         success: true,
-        message: `Found node at ${remoteOnlineHost}:${remoteOnlinePort}`,
         id: nodesUtils.encodeNodeId(remoteOnlineNodeId),
-        host: remoteOnlineHost,
-        port: remoteOnlinePort,
       });
+      expect(output.addresses).toEqual(
+        expect.arrayContaining([
+          {
+            host: remoteOnlineHost,
+            port: remoteOnlinePort,
+          },
+        ]),
+      );
+      expect(output.message).toMatch(
+        new RegExp(
+          `Found node at .*?${remoteOnlineHost}:${remoteOnlinePort}.*?`,
+        ),
+      );
     },
   );
   testUtils.testIf(testUtils.isTestPlatformEmpty)(
@@ -145,13 +156,24 @@ describe('find', () => {
         },
       );
       expect(exitCode).toBe(0);
-      expect(JSON.parse(stdout)).toEqual({
+      const output = JSON.parse(stdout);
+      expect(output).toMatchObject({
         success: true,
-        message: `Found node at ${remoteOfflineHost}:${remoteOfflinePort}`,
         id: nodesUtils.encodeNodeId(remoteOfflineNodeId),
-        host: remoteOfflineHost,
-        port: remoteOfflinePort,
       });
+      expect(output.addresses).toEqual(
+        expect.arrayContaining([
+          {
+            host: remoteOfflineHost,
+            port: remoteOfflinePort,
+          },
+        ]),
+      );
+      expect(output.message).toMatch(
+        new RegExp(
+          `Found node at .*?${remoteOfflineHost}:${remoteOfflinePort}.*?`,
+        ),
+      );
     },
   );
   testUtils.testIf(testUtils.isTestPlatformEmpty)(
@@ -183,8 +205,7 @@ describe('find', () => {
           unknownNodeId!,
         )}`,
         id: nodesUtils.encodeNodeId(unknownNodeId!),
-        host: '',
-        port: 0,
+        addresses: [],
       });
     },
     globalThis.failedConnectionTimeout,

--- a/tests/nodes/ping.test.ts
+++ b/tests/nodes/ping.test.ts
@@ -35,9 +35,6 @@ describe('ping', () => {
           passwordMemLimit: keysUtils.passwordMemLimits.min,
           strictMemoryLock: false,
         },
-        nodes: {
-          connectionConnectTimeoutTime: 2000,
-        },
       },
       logger,
     });

--- a/tests/utils/utils.ts
+++ b/tests/utils/utils.ts
@@ -1,5 +1,4 @@
 import type PolykeyAgent from 'polykey/dist/PolykeyAgent';
-import type { NodeAddress } from 'polykey/dist/nodes/types';
 import { promise } from 'polykey/dist/utils/utils';
 
 function testIf(condition: boolean) {
@@ -69,12 +68,14 @@ async function nodesConnect(localNode: PolykeyAgent, remoteNode: PolykeyAgent) {
   await localNode.nodeManager.setNode(remoteNode.keyRing.getNodeId(), {
     host: remoteNode.agentServiceHost,
     port: remoteNode.agentServicePort,
-  } as NodeAddress);
+    scopes: ['global'],
+  });
   // Add local node's details to remote node
   await remoteNode.nodeManager.setNode(localNode.keyRing.getNodeId(), {
     host: localNode.agentServiceHost,
     port: localNode.agentServicePort,
-  } as NodeAddress);
+    scopes: ['global'],
+  });
 }
 
 export { testIf, describeIf, trackTimers, nodesConnect };

--- a/tests/vaults/vaults.test.ts
+++ b/tests/vaults/vaults.test.ts
@@ -1,4 +1,3 @@
-import type { NodeAddress } from 'polykey/dist/nodes/types';
 import type { VaultId, VaultName } from 'polykey/dist/vaults/types';
 import type { GestaltNodeInfo } from 'polykey/dist/gestalts/types';
 import path from 'path';
@@ -258,12 +257,14 @@ describe('CLI vaults', () => {
       await polykeyAgent.nodeManager.setNode(targetNodeId, {
         host: targetPolykeyAgent.agentServiceHost,
         port: targetPolykeyAgent.agentServicePort,
+        scopes: ['global'],
       });
       await targetPolykeyAgent.nodeManager.setNode(
         polykeyAgent.keyRing.getNodeId(),
         {
           host: polykeyAgent.agentServiceHost,
           port: polykeyAgent.agentServicePort,
+          scopes: ['global'],
         },
       );
       await polykeyAgent.acl.setNodePerm(targetNodeId, {
@@ -834,7 +835,8 @@ describe('CLI vaults', () => {
           await polykeyAgent.nodeManager.setNode(remoteOnlineNodeId, {
             host: remoteOnline.agentServiceHost,
             port: remoteOnline.agentServicePort,
-          } as NodeAddress);
+            scopes: ['global'],
+          });
 
           await remoteOnline.gestaltGraph.setNode({
             nodeId: polykeyAgent.keyRing.getNodeId(),


### PR DESCRIPTION
### Description
As of `polykey` `1.2.1-alpha.20`, `js-mdns` has been integrated for the sake of local discovery. Changes to `nodes/CommandFind` and related tests will need to be changed in order to support the `scopes` property on `NodeAddress`, and that some RPCCalls now return `Array<NodeAddress>` rather than `NodeAddress`.

### Issues Fixed
None

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Change `nodes/CommandFind` to output multiple addresses
- [x] 2. Amend related tests

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [ ] Domain specific tests
* [ ] Full tests
* [ ] Updated inline-comment documentation
* [ ] Lint fixed
* [ ] Squash and rebased
* [ ] Sanity check the final build
