### PR TITLE
Stdout standardization with output formatter

### DIFF
--- a/src/agent/CommandStatus.ts
+++ b/src/agent/CommandStatus.ts
@@ -81,15 +81,14 @@ class CommandStatus extends CommandPolykey {
               agentHost: response.agentHost,
               agentPort: response.agentPort,
               upTime: getUnixtime() - response.startTime,
+              startTime: response.startTime,
               connectionsActive: response.connectionsActive,
               nodesTotal: response.nodesTotal,
               version: response.version,
               sourceVersion: response.sourceVersion,
               stateVersion: response.stateVersion,
               networkVersion: response.networkVersion,
-              ...(options.format === 'json'
-                ? { versionMetadata: response.versionMetadata }
-                : response.versionMetadata),
+              versionMetadata: response.versionMetadata,
             },
           }),
         );

--- a/src/agent/CommandStatus.ts
+++ b/src/agent/CommandStatus.ts
@@ -87,7 +87,9 @@ class CommandStatus extends CommandPolykey {
               sourceVersion: response.sourceVersion,
               stateVersion: response.stateVersion,
               networkVersion: response.networkVersion,
-              ...response.versionMetadata,
+              ...(options.format === 'json'
+                ? { versionMetadata: response.versionMetadata }
+                : response.versionMetadata),
             },
           }),
         );

--- a/src/agent/CommandStop.ts
+++ b/src/agent/CommandStop.ts
@@ -27,13 +27,13 @@ class CommandStop extends CommandPolykey {
       );
       const statusInfo = clientStatus.statusInfo;
       if (statusInfo?.status === 'DEAD') {
-        this.logger.info('Agent is already dead');
+        process.stderr.write('Agent is already dead\n');
         return;
       } else if (statusInfo?.status === 'STOPPING') {
-        this.logger.info('Agent is already stopping');
+        process.stderr.write('Agent is already stopping\n');
         return;
       } else if (statusInfo?.status === 'STARTING') {
-        throw new errors.ErrorPolykeyCLIAgentStatus('agent is starting');
+        throw new errors.ErrorPolykeyCLIAgentStatus('Agent is starting');
       }
       const auth = await binProcessors.processAuthentication(
         options.passwordFile,
@@ -62,7 +62,7 @@ class CommandStop extends CommandPolykey {
             }),
           auth,
         );
-        this.logger.info('Stopping Agent');
+        process.stderr.write('Stopping Agent\n');
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/bootstrap/CommandBootstrap.ts
+++ b/src/bootstrap/CommandBootstrap.ts
@@ -1,5 +1,6 @@
 import process from 'process';
 import CommandPolykey from '../CommandPolykey';
+import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
 import * as binProcessors from '../utils/processors';
 
@@ -36,7 +37,14 @@ class CommandBootstrap extends CommandPolykey {
         logger: this.logger,
       });
       this.logger.info(`Bootstrapped ${options.nodePath}`);
-      if (recoveryCodeOut != null) process.stdout.write(recoveryCodeOut + '\n');
+      process.stdout.write(
+        binUtils.outputFormatter({
+          type: options.format === 'json' ? 'json' : 'dict',
+          data: {
+            recoveryCode: recoveryCodeOut,
+          },
+        }),
+      );
     });
   }
 }

--- a/src/identities/CommandAuthenticate.ts
+++ b/src/identities/CommandAuthenticate.ts
@@ -80,17 +80,27 @@ class CommandAuthenticate extends CommandPolykey {
                 if (e.code !== 'ENOENT') throw e;
                 // Otherwise we ignore `ENOENT` as a failure to spawn a browser
               }
-              process.stdout.write(
-                binUtils.outputFormatter({
-                  type: options.format === 'json' ? 'json' : 'dict',
-                  data: {
-                    url: message.request.url,
-                    ...(options.format === 'json'
-                      ? { dataMap: message.request.dataMap }
-                      : message.request.dataMap),
-                  },
-                }),
-              );
+              if (options.format === 'json') {
+                process.stdout.write(
+                  binUtils.outputFormatter({
+                    type: 'json',
+                    data: {
+                      url: message.request.url,
+                      dataMap: message.request.dataMap,
+                    },
+                  }),
+                );
+              } else {
+                process.stdout.write(
+                  binUtils.outputFormatter({
+                    type: 'dict',
+                    data: {
+                      url: message.request.url,
+                      ...message.request.dataMap,
+                    },
+                  }),
+                );
+              }
             } else if (message.response != null) {
               process.stderr.write(
                 `Authenticated digital identity provider ${providerId}\n`,

--- a/src/identities/CommandAuthenticate.ts
+++ b/src/identities/CommandAuthenticate.ts
@@ -83,7 +83,9 @@ class CommandAuthenticate extends CommandPolykey {
                   type: options.format === 'json' ? 'json' : 'dict',
                   data: {
                     url: message.request.url,
-                    ...message.request.dataMap,
+                    ...(options.format === 'json'
+                      ? { dataMap: message.request.dataMap }
+                      : message.request.dataMap),
                   },
                 }),
               );
@@ -91,16 +93,12 @@ class CommandAuthenticate extends CommandPolykey {
               this.logger.info(
                 `Authenticated digital identity provider ${providerId}`,
               );
-              let output: string | Uint8Array;
-              if (options.format === 'json') {
-                output = binUtils.outputFormatter({
-                  type: 'json',
+              process.stdout.write(
+                binUtils.outputFormatter({
+                  type: options.format === 'json' ? 'json' : 'dict',
                   data: { identityId: message.response.identityId },
-                });
-              } else {
-                output = `${message.response.identityId}\n`;
-              }
-              process.stdout.write(output);
+                }),
+              );
             } else {
               never();
             }

--- a/src/identities/CommandAuthenticate.ts
+++ b/src/identities/CommandAuthenticate.ts
@@ -91,12 +91,16 @@ class CommandAuthenticate extends CommandPolykey {
               this.logger.info(
                 `Authenticated digital identity provider ${providerId}`,
               );
-              process.stdout.write(
-                binUtils.outputFormatter({
-                  type: options.format === 'json' ? 'json' : 'list',
-                  data: [message.response.identityId],
-                }),
-              );
+              let output: string | Uint8Array;
+              if (options.format === 'json') {
+                output = binUtils.outputFormatter({
+                  type: 'json',
+                  data: { identityId: message.response.identityId },
+                });
+              } else {
+                output = `${message.response.identityId}\n`;
+              }
+              process.stdout.write(output);
             } else {
               never();
             }

--- a/src/identities/CommandAuthenticate.ts
+++ b/src/identities/CommandAuthenticate.ts
@@ -68,9 +68,11 @@ class CommandAuthenticate extends CommandPolykey {
           );
           for await (const message of genReadable) {
             if (message.request != null) {
-              this.logger.info(`Navigate to the URL in order to authenticate`);
-              this.logger.info(
-                'Use any additional additional properties to complete authentication',
+              process.stderr.write(
+                `Navigate to the URL in order to authenticate\n`,
+              );
+              process.stderr.write(
+                'Use any additional additional properties to complete authentication\n',
               );
               try {
                 await identitiesUtils.browser(message.request.url);
@@ -90,8 +92,8 @@ class CommandAuthenticate extends CommandPolykey {
                 }),
               );
             } else if (message.response != null) {
-              this.logger.info(
-                `Authenticated digital identity provider ${providerId}`,
+              process.stderr.write(
+                `Authenticated digital identity provider ${providerId}\n`,
               );
               process.stdout.write(
                 binUtils.outputFormatter({

--- a/src/identities/CommandClaim.ts
+++ b/src/identities/CommandClaim.ts
@@ -60,14 +60,16 @@ class CommandClaim extends CommandPolykey {
               }),
             auth,
           );
-          const output = [`Claim Id: ${claimMessage.claimId}`];
+          const data: { claimId: string; url?: string } = {
+            claimId: claimMessage.claimId,
+          };
           if (claimMessage.url) {
-            output.push(`Url: ${claimMessage.url}`);
+            data.url = claimMessage.url;
           }
           process.stdout.write(
             binUtils.outputFormatter({
-              type: options.format === 'json' ? 'json' : 'list',
-              data: output,
+              type: options.format === 'json' ? 'json' : 'dict',
+              data,
             }),
           );
         } finally {

--- a/src/identities/CommandGet.ts
+++ b/src/identities/CommandGet.ts
@@ -88,10 +88,17 @@ class CommandGet extends CommandPolykey {
             utils.never();
         }
         const gestalt = res!.gestalt;
-        let output: any = gestalt;
-        if (options.format !== 'json') {
-          // Creating a list.
-          output = [];
+        if (options.format === 'json') {
+          process.stdout.write(
+            binUtils.outputFormatter({
+              type: 'json',
+              data: {
+                gestalt,
+              },
+            }),
+          );
+        } else {
+          const output: Array<string> = [];
           // Listing nodes.
           for (const nodeKey of Object.keys(gestalt.nodes)) {
             const node = gestalt.nodes[nodeKey];
@@ -102,13 +109,13 @@ class CommandGet extends CommandPolykey {
             const identity = gestalt.identities[identityKey];
             output.push(`${identity.providerId}:${identity.identityId}`);
           }
+          process.stdout.write(
+            binUtils.outputFormatter({
+              type: 'list',
+              data: output,
+            }),
+          );
         }
-        process.stdout.write(
-          binUtils.outputFormatter({
-            type: options.format === 'json' ? 'json' : 'list',
-            data: output,
-          }),
-        );
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/identities/CommandInvite.ts
+++ b/src/identities/CommandInvite.ts
@@ -59,10 +59,10 @@ class CommandClaim extends CommandPolykey {
             }),
           auth,
         );
-        this.logger.info(
+        process.stderr.write(
           `Successfully sent Gestalt Invite notification to Keynode with ID ${nodesUtils.encodeNodeId(
             nodeId,
-          )}`,
+          )}\n`,
         );
       } finally {
         if (pkClient! != null) await pkClient.stop();

--- a/src/identities/CommandInvite.ts
+++ b/src/identities/CommandInvite.ts
@@ -59,19 +59,11 @@ class CommandClaim extends CommandPolykey {
             }),
           auth,
         );
-        const message = `Successfully sent Gestalt Invite notification to Keynode with ID ${nodesUtils.encodeNodeId(
-          nodeId,
-        )}`;
-        let output: string | Uint8Array;
-        if (options.format === 'json') {
-          output = binUtils.outputFormatter({
-            type: 'json',
-            data: { message },
-          });
-        } else {
-          output = `${message}\n`;
-        }
-        process.stdout.write(output);
+        this.logger.info(
+          `Successfully sent Gestalt Invite notification to Keynode with ID ${nodesUtils.encodeNodeId(
+            nodeId,
+          )}`,
+        );
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/identities/CommandInvite.ts
+++ b/src/identities/CommandInvite.ts
@@ -59,16 +59,19 @@ class CommandClaim extends CommandPolykey {
             }),
           auth,
         );
-        process.stdout.write(
-          binUtils.outputFormatter({
-            type: options.format === 'json' ? 'json' : 'list',
-            data: [
-              `Successfully sent Gestalt Invite notification to Keynode with ID ${nodesUtils.encodeNodeId(
-                nodeId,
-              )}`,
-            ],
-          }),
-        );
+        const message = `Successfully sent Gestalt Invite notification to Keynode with ID ${nodesUtils.encodeNodeId(
+          nodeId,
+        )}`;
+        let output: string | Uint8Array;
+        if (options.format === 'json') {
+          output = binUtils.outputFormatter({
+            type: 'json',
+            data: { message },
+          });
+        } else {
+          output = `${message}\n`;
+        }
+        process.stdout.write(output);
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/identities/CommandList.ts
+++ b/src/identities/CommandList.ts
@@ -1,4 +1,5 @@
 import type PolykeyClient from 'polykey/dist/PolykeyClient';
+import type { GestaltMessage } from 'polykey/dist/client/types';
 import CommandPolykey from '../CommandPolykey';
 import * as binOptions from '../utils/options';
 import * as binUtils from '../utils';
@@ -42,72 +43,70 @@ class CommandList extends CommandPolykey {
           },
           logger: this.logger.getChild(PolykeyClient.name),
         });
-        const gestalts = await binUtils.retryAuthentication(async (auth) => {
-          const gestalts: Array<any> = [];
-          const stream = await pkClient.rpcClient.methods.gestaltsGestaltList({
-            metadata: auth,
-          });
-          for await (const gestaltMessage of stream) {
-            const gestalt = gestaltMessage.gestalt;
-            const newGestalt: any = {
-              permissions: [],
-              nodes: [],
-              identities: [],
-            };
-            for (const node of Object.keys(gestalt.nodes)) {
-              const nodeInfo = gestalt.nodes[node];
-              newGestalt.nodes.push({ nodeId: nodeInfo.nodeId });
-            }
-            for (const identity of Object.keys(gestalt.identities)) {
-              const identityInfo = gestalt.identities[identity];
-              newGestalt.identities.push({
-                providerId: identityInfo.providerId,
-                identityId: identityInfo.identityId,
+        const gestaltMessages = await binUtils.retryAuthentication(
+          async (auth) => {
+            const gestaltMessages: Array<
+              GestaltMessage & { gestalt: { actionsList: Array<string> } }
+            > = [];
+            const stream = await pkClient.rpcClient.methods.gestaltsGestaltList(
+              {
+                metadata: auth,
+              },
+            );
+            for await (const gestaltMessage of stream) {
+              // Getting the permissions for the gestalt.
+              const actionsMessage = await binUtils.retryAuthentication(
+                (auth) =>
+                  pkClient.rpcClient.methods.gestaltsActionsGetByNode({
+                    metadata: auth,
+                    nodeIdEncoded: Object.values(
+                      gestaltMessage.gestalt.nodes,
+                    )[0].nodeId,
+                  }),
+                auth,
+              );
+              const actionsList = actionsMessage.actionsList;
+              gestaltMessages.push({
+                gestalt: {
+                  ...gestaltMessage.gestalt,
+                  actionsList,
+                },
               });
             }
-            // Getting the permissions for the gestalt.
-            const actionsMessage = await binUtils.retryAuthentication(
-              (auth) =>
-                pkClient.rpcClient.methods.gestaltsActionsGetByNode({
-                  metadata: auth,
-                  nodeIdEncoded: newGestalt.nodes[0].nodeId,
-                }),
-              auth,
-            );
-            const actionList = actionsMessage.actionsList;
-            if (actionList.length === 0) newGestalt.permissions = null;
-            else newGestalt.permissions = actionList;
-            gestalts.push(newGestalt);
-          }
-          return gestalts;
-        }, auth);
+            return gestaltMessages;
+          },
+          auth,
+        );
         if (options.format === 'json') {
           process.stdout.write(
             binUtils.outputFormatter({
-              type: options.format === 'json' ? 'json' : 'list',
-              data: gestalts,
+              type: 'json',
+              data: gestaltMessages,
             }),
           );
         } else {
           // Convert to a human-readable list.
           let count = 1;
-          for (const gestalt of gestalts) {
+          for (const gestaltMessage of gestaltMessages) {
+            const gestalt = gestaltMessage.gestalt;
+            if (count !== 1) process.stdout.write('\n');
             process.stdout.write(
               binUtils.outputFormatter({
                 type: 'dict',
                 data: {
                   gestalt: count,
-                  permissions: gestalt.permissions,
+                  actionsList: gestalt.actionsList.join(','),
                 },
               }),
             );
             // Listing nodes
-            const nodeIds = gestalt.nodes.map((node) => node.nodeId);
+            const nodeIds = Object.values(gestalt.nodes).map(
+              (node) => node.nodeId as string,
+            );
             // Listing identities
-            const identities = gestalt.identities.map(
+            const identities = Object.values(gestalt.identities).map(
               (identity) => `${identity.providerId}:${identity.identityId}`,
             );
-            if (count !== 1) process.stdout.write('\n');
             process.stdout.write(
               binUtils.outputFormatter({
                 type: 'list',

--- a/src/identities/CommandList.ts
+++ b/src/identities/CommandList.ts
@@ -86,7 +86,6 @@ class CommandList extends CommandPolykey {
           );
         } else {
           // Convert to a human-readable list.
-          let count = 1;
           for (const gestaltMessage of gestaltMessages) {
             const gestalt = gestaltMessage.gestalt;
             const nodeIds = Object.values(gestalt.nodes).map(
@@ -99,14 +98,14 @@ class CommandList extends CommandPolykey {
               binUtils.outputFormatter({
                 type: 'dict',
                 data: {
-                  gestalt: count,
-                  actionsList: gestalt.actionsList.join(','),
-                  identities,
-                  nodeIds,
+                  gestalt: {
+                    actionsList: gestalt.actionsList.join(','),
+                    identities,
+                    nodeIds,
+                  },
                 },
               }),
             );
-            count++;
           }
         }
       } finally {

--- a/src/identities/CommandList.ts
+++ b/src/identities/CommandList.ts
@@ -90,27 +90,21 @@ class CommandList extends CommandPolykey {
           for (const gestaltMessage of gestaltMessages) {
             const gestalt = gestaltMessage.gestalt;
             if (count !== 1) process.stdout.write('\n');
+            const nodeIds = Object.values(gestalt.nodes).map(
+              (node) => node.nodeId as string,
+            );
+            const identities = Object.values(gestalt.identities).map(
+              (identity) => `${identity.providerId}:${identity.identityId}`,
+            );
             process.stdout.write(
               binUtils.outputFormatter({
                 type: 'dict',
                 data: {
                   gestalt: count,
                   actionsList: gestalt.actionsList.join(','),
+                  identities,
+                  nodeIds,
                 },
-              }),
-            );
-            // Listing nodes
-            const nodeIds = Object.values(gestalt.nodes).map(
-              (node) => node.nodeId as string,
-            );
-            // Listing identities
-            const identities = Object.values(gestalt.identities).map(
-              (identity) => `${identity.providerId}:${identity.identityId}`,
-            );
-            process.stdout.write(
-              binUtils.outputFormatter({
-                type: 'list',
-                data: nodeIds.concat(identities),
               }),
             );
             count++;

--- a/src/identities/CommandList.ts
+++ b/src/identities/CommandList.ts
@@ -89,7 +89,6 @@ class CommandList extends CommandPolykey {
           let count = 1;
           for (const gestaltMessage of gestaltMessages) {
             const gestalt = gestaltMessage.gestalt;
-            if (count !== 1) process.stdout.write('\n');
             const nodeIds = Object.values(gestalt.nodes).map(
               (node) => node.nodeId as string,
             );

--- a/src/identities/CommandList.ts
+++ b/src/identities/CommandList.ts
@@ -107,11 +107,12 @@ class CommandList extends CommandPolykey {
             const identities = gestalt.identities.map(
               (identity) => `${identity.providerId}:${identity.identityId}`,
             );
+            if (count !== 1) process.stdout.write('\n');
             process.stdout.write(
               binUtils.outputFormatter({
                 type: 'list',
                 data: nodeIds.concat(identities),
-              }) + '\n',
+              }),
             );
             count++;
           }

--- a/src/identities/CommandPermissions.ts
+++ b/src/identities/CommandPermissions.ts
@@ -52,7 +52,7 @@ class CommandPermissions extends CommandPolykey {
           logger: this.logger.getChild(PolykeyClient.name),
         });
         const [type, id] = gestaltId;
-        let actions: Array<string> = [];
+        let actionsList: Array<string> = [];
         switch (type) {
           case 'node':
             {
@@ -65,7 +65,7 @@ class CommandPermissions extends CommandPolykey {
                   }),
                 auth,
               );
-              actions = res.actionsList;
+              actionsList = res.actionsList;
             }
             break;
           case 'identity':
@@ -80,7 +80,7 @@ class CommandPermissions extends CommandPolykey {
                   }),
                 auth,
               );
-              actions = res.actionsList;
+              actionsList = res.actionsList;
             }
             break;
           default:
@@ -90,7 +90,7 @@ class CommandPermissions extends CommandPolykey {
           binUtils.outputFormatter({
             type: options.format === 'json' ? 'json' : 'dict',
             data: {
-              permissions: actions,
+              actionsList,
             },
           }),
         );

--- a/src/identities/CommandPermissions.ts
+++ b/src/identities/CommandPermissions.ts
@@ -86,14 +86,25 @@ class CommandPermissions extends CommandPolykey {
           default:
             utils.never();
         }
-        process.stdout.write(
-          binUtils.outputFormatter({
-            type: options.format === 'json' ? 'json' : 'dict',
-            data: {
-              actionsList,
-            },
-          }),
-        );
+        if (options.format === 'json') {
+          process.stdout.write(
+            binUtils.outputFormatter({
+              type: 'json',
+              data: {
+                actionsList,
+              },
+            }),
+          );
+        } else {
+          process.stdout.write(
+            binUtils.outputFormatter({
+              type: 'dict',
+              data: {
+                actionsList: actionsList.join(','),
+              },
+            }),
+          );
+        }
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/identities/CommandSearch.ts
+++ b/src/identities/CommandSearch.ts
@@ -2,6 +2,7 @@ import type PolykeyClient from 'polykey/dist/PolykeyClient';
 import type { IdentityInfoMessage } from 'polykey/dist/client/types';
 import type { ReadableStream } from 'stream/web';
 import type { ClientRPCResponseResult } from 'polykey/dist/client/types';
+import { TransformStream } from 'stream/web';
 import CommandPolykey from '../CommandPolykey';
 import * as binOptions from '../utils/options';
 import * as binUtils from '../utils';
@@ -101,20 +102,44 @@ class CommandSearch extends CommandPolykey {
                 limit: options.limit,
               });
           }
-          for await (const identityInfoMessage of readableStream) {
-            const output = {
-              providerId: identityInfoMessage.providerId,
-              identityId: identityInfoMessage.identityId,
-              name: identityInfoMessage.name,
-              email: identityInfoMessage.email,
-              url: identityInfoMessage.url,
-            };
-            process.stdout.write(
-              binUtils.outputFormatter({
-                type: options.format === 'json' ? 'json' : 'dict',
-                data: output,
-              }),
-            );
+          readableStream = readableStream.pipeThrough(
+            new TransformStream({
+              transform: (chunk, controller) => {
+                controller.enqueue({
+                  providerId: chunk.providerId,
+                  identityId: chunk.identityId,
+                  name: chunk.name,
+                  email: chunk.email,
+                  url: chunk.url,
+                });
+              },
+            }),
+          );
+          if (options.format === 'json') {
+            for await (const output of readableStream) {
+              process.stdout.write(
+                binUtils.outputFormatter({
+                  type: options.format === 'json' ? 'json' : 'dict',
+                  data: output,
+                }),
+              );
+            }
+          } else {
+            let firstElement = true;
+            for await (const output of readableStream) {
+              if (!firstElement) {
+                process.stdout.write('\n');
+              }
+              process.stdout.write(
+                binUtils.outputFormatter({
+                  type: 'dict',
+                  data: output,
+                }),
+              );
+              if (firstElement) {
+                firstElement = false;
+              }
+            }
           }
         }, auth);
       } finally {

--- a/src/identities/CommandSearch.ts
+++ b/src/identities/CommandSearch.ts
@@ -125,20 +125,13 @@ class CommandSearch extends CommandPolykey {
               );
             }
           } else {
-            let firstElement = true;
             for await (const output of readableStream) {
-              if (!firstElement) {
-                process.stdout.write('\n');
-              }
               process.stdout.write(
                 binUtils.outputFormatter({
                   type: 'dict',
                   data: output,
                 }),
               );
-              if (firstElement) {
-                firstElement = false;
-              }
             }
           }
         }, auth);

--- a/src/keys/CommandCert.ts
+++ b/src/keys/CommandCert.ts
@@ -49,17 +49,12 @@ class CommandCert extends CommandPolykey {
             }),
           auth,
         );
-        const result = {
-          cert: response.cert,
-        };
-        let output: any = result;
-        if (options.format === 'human') {
-          output = ['Root certificate:', result.cert];
-        }
         process.stdout.write(
           binUtils.outputFormatter({
-            type: options.format === 'json' ? 'json' : 'list',
-            data: output,
+            type: options.format === 'json' ? 'json' : 'dict',
+            data: {
+              cert: response.cert,
+            },
           }),
         );
       } finally {

--- a/src/keys/CommandCert.ts
+++ b/src/keys/CommandCert.ts
@@ -49,14 +49,23 @@ class CommandCert extends CommandPolykey {
             }),
           auth,
         );
-        process.stdout.write(
-          binUtils.outputFormatter({
-            type: options.format === 'json' ? 'json' : 'dict',
-            data: {
-              cert: response.cert,
-            },
-          }),
-        );
+        if (options.format === 'json') {
+          process.stdout.write(
+            binUtils.outputFormatter({
+              type: 'json',
+              data: {
+                cert: response.cert,
+              },
+            }),
+          );
+        } else {
+          process.stdout.write(
+            binUtils.outputFormatter({
+              type: 'raw',
+              data: response.cert,
+            }),
+          );
+        }
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/keys/CommandCertchain.ts
+++ b/src/keys/CommandCertchain.ts
@@ -52,23 +52,12 @@ class CommandsCertchain extends CommandPolykey {
           }
           return data;
         }, auth);
-        if (options.format === 'json') {
-          process.stdout.write(
-            binUtils.outputFormatter({
-              type: 'json',
-              data: {
-                certchain: data,
-              },
-            }),
-          );
-        } else {
-          process.stdout.write(
-            binUtils.outputFormatter({
-              type: 'list',
-              data,
-            }),
-          );
-        }
+        process.stdout.write(
+          binUtils.outputFormatter({
+            type: options.format === 'json' ? 'json' : 'list',
+            data: data,
+          }),
+        );
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/keys/CommandCertchain.ts
+++ b/src/keys/CommandCertchain.ts
@@ -52,19 +52,23 @@ class CommandsCertchain extends CommandPolykey {
           }
           return data;
         }, auth);
-        const result = {
-          certchain: data,
-        };
-        let output: any = result;
-        if (options.format === 'human') {
-          output = ['Root Certificate Chain:', ...result.certchain];
+        if (options.format === 'json') {
+          process.stdout.write(
+            binUtils.outputFormatter({
+              type: 'json',
+              data: {
+                certchain: data,
+              },
+            }),
+          );
+        } else {
+          process.stdout.write(
+            binUtils.outputFormatter({
+              type: 'list',
+              data,
+            }),
+          );
         }
-        process.stdout.write(
-          binUtils.outputFormatter({
-            type: options.format === 'json' ? 'json' : 'list',
-            data: output,
-          }),
-        );
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/keys/CommandDecrypt.ts
+++ b/src/keys/CommandDecrypt.ts
@@ -71,19 +71,23 @@ class CommandDecrypt extends CommandPolykey {
             }),
           auth,
         );
-        const result = {
-          decryptedData: response.data,
-        };
-        let output: any = result;
-        if (options.format === 'human') {
-          output = { 'Decrypted data:': result.decryptedData };
+        if (options.format === 'json') {
+          process.stdout.write(
+            binUtils.outputFormatter({
+              type: 'json',
+              data: {
+                data: response.data,
+              },
+            }),
+          );
+        } else {
+          process.stdout.write(
+            binUtils.outputFormatter({
+              type: 'raw',
+              data: response.data,
+            }),
+          );
         }
-        process.stdout.write(
-          binUtils.outputFormatter({
-            type: options.format === 'json' ? 'json' : 'dict',
-            data: output,
-          }),
-        );
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/keys/CommandEncrypt.ts
+++ b/src/keys/CommandEncrypt.ts
@@ -98,19 +98,23 @@ class CommandEncypt extends CommandPolykey {
             }),
           auth,
         );
-        const result = {
-          encryptedData: response.data,
-        };
-        let output: any = result;
-        if (options.format === 'human') {
-          output = { 'Encrypted data:': result.encryptedData };
+        if (options.format === 'json') {
+          process.stdout.write(
+            binUtils.outputFormatter({
+              type: 'json',
+              data: {
+                data: response.data,
+              },
+            }),
+          );
+        } else {
+          process.stdout.write(
+            binUtils.outputFormatter({
+              type: 'raw',
+              data: response.data,
+            }),
+          );
         }
-        process.stdout.write(
-          binUtils.outputFormatter({
-            type: options.format === 'json' ? 'json' : 'dict',
-            data: output,
-          }),
-        );
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/keys/CommandPair.ts
+++ b/src/keys/CommandPair.ts
@@ -59,8 +59,8 @@ class CommandKeypair extends CommandPolykey {
           auth,
         );
         const pair = {
-          publicKey: keyPairJWK.publicKeyJwk,
-          privateKey: keyPairJWK.privateKeyJwe,
+          publicKeyJwk: keyPairJWK.publicKeyJwk,
+          privateKeyJwe: keyPairJWK.privateKeyJwe,
         };
         process.stdout.write(
           binUtils.outputFormatter({

--- a/src/keys/CommandSign.ts
+++ b/src/keys/CommandSign.ts
@@ -71,17 +71,12 @@ class CommandSign extends CommandPolykey {
             }),
           auth,
         );
-        const result = {
-          signature: response.signature,
-        };
-        let output: any = result;
-        if (options.format === 'human') {
-          output = { 'Signature:': result.signature };
-        }
         process.stdout.write(
           binUtils.outputFormatter({
             type: options.format === 'json' ? 'json' : 'dict',
-            data: output,
+            data: {
+              signature: response.signature,
+            },
           }),
         );
       } finally {

--- a/src/keys/CommandVerify.ts
+++ b/src/keys/CommandVerify.ts
@@ -111,7 +111,7 @@ class CommandVerify extends CommandPolykey {
           binUtils.outputFormatter({
             type: options.format === 'json' ? 'json' : 'dict',
             data: {
-              signatureVerified: response.success,
+              success: response.success,
             },
           }),
         );

--- a/src/keys/CommandVerify.ts
+++ b/src/keys/CommandVerify.ts
@@ -107,17 +107,12 @@ class CommandVerify extends CommandPolykey {
             }),
           auth,
         );
-        const result = {
-          signatureVerified: response.success,
-        };
-        let output: any = result;
-        if (options.format === 'human') {
-          output = { 'Signature verified:': result.signatureVerified };
-        }
         process.stdout.write(
           binUtils.outputFormatter({
             type: options.format === 'json' ? 'json' : 'dict',
-            data: output,
+            data: {
+              signatureVerified: response.success,
+            },
           }),
         );
       } finally {

--- a/src/nodes/CommandClaim.ts
+++ b/src/nodes/CommandClaim.ts
@@ -63,28 +63,27 @@ class CommandClaim extends CommandPolykey {
             }),
           auth,
         );
-        const claimed = response.success;
-        if (claimed) {
-          const outputFormatted = binUtils.outputFormatter({
-            type: options.format === 'json' ? 'json' : 'list',
-            data: [
-              `Successfully generated a cryptolink claim on Keynode with ID ${nodesUtils.encodeNodeId(
-                nodeId,
-              )}`,
-            ],
-          });
-          process.stdout.write(outputFormatted);
+        if (response.success) {
+          process.stderr.write(
+            `Successfully generated a cryptolink claim on Keynode with ID ${nodesUtils.encodeNodeId(
+              nodeId,
+            )}\n`,
+          );
         } else {
-          const outputFormatted = binUtils.outputFormatter({
-            type: options.format === 'json' ? 'json' : 'list',
-            data: [
-              `Successfully sent Gestalt Invite notification to Keynode with ID ${nodesUtils.encodeNodeId(
-                nodeId,
-              )}`,
-            ],
-          });
-          process.stdout.write(outputFormatted);
+          process.stderr.write(
+            `Successfully sent Gestalt Invite notification to Keynode with ID ${nodesUtils.encodeNodeId(
+              nodeId,
+            )}\n`,
+          );
         }
+        process.stdout.write(
+          binUtils.outputFormatter({
+            type: options.format === 'json' ? 'json' : 'dict',
+            data: {
+              success: response.success,
+            },
+          }),
+        );
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/nodes/CommandConnections.ts
+++ b/src/nodes/CommandConnections.ts
@@ -57,7 +57,14 @@ class CommandAdd extends CommandPolykey {
           }
           return connectionEntries;
         }, auth);
-        if (options.format === 'human') {
+        if (options.format === 'json') {
+          // Wait for outputFormatter to complete and then write to stdout
+          const outputFormatted = binUtils.outputFormatter({
+            type: 'json',
+            data: connections,
+          });
+          process.stdout.write(outputFormatted);
+        } else {
           // Wait for outputFormatter to complete and then write to stdout
           const outputFormatted = binUtils.outputFormatter({
             type: 'table',
@@ -73,13 +80,6 @@ class CommandAdd extends CommandPolykey {
               ],
               includeHeaders: true,
             },
-          });
-          process.stdout.write(outputFormatted);
-        } else {
-          // Wait for outputFormatter to complete and then write to stdout
-          const outputFormatted = binUtils.outputFormatter({
-            type: 'json',
-            data: connections,
           });
           process.stdout.write(outputFormatted);
         }

--- a/src/nodes/CommandFind.ts
+++ b/src/nodes/CommandFind.ts
@@ -95,6 +95,7 @@ class CommandFind extends CommandPolykey {
                 data: {
                   nodeAddress: formattedNodeAddress,
                   ...response.nodeContactAddressData,
+                  scopes: response.nodeContactAddressData.scopes.join(','),
                 },
               }),
             );

--- a/src/nodes/CommandGetAll.ts
+++ b/src/nodes/CommandGetAll.ts
@@ -70,12 +70,12 @@ class CommandGetAll extends CommandPolykey {
             binUtils.outputFormatter({
               type: 'table',
               options: {
-                columns: ['nodeIdEncoded', 'address', 'bucketIndex'],
+                columns: ['nodeIdEncoded', 'nodeAddress', 'bucketIndex'],
               },
               data: result.flatMap((nodesGetMessage) =>
-                Object.keys(nodesGetMessage.nodeContact).map((address) => ({
+                Object.keys(nodesGetMessage.nodeContact).map((nodeAddress) => ({
                   nodeIdEncoded: nodesGetMessage.nodeIdEncoded,
-                  address,
+                  nodeAddress,
                   bucketIndex: nodesGetMessage.bucketIndex,
                 })),
               ),

--- a/src/nodes/CommandGetAll.ts
+++ b/src/nodes/CommandGetAll.ts
@@ -57,25 +57,41 @@ class CommandGetAll extends CommandPolykey {
           },
           auth,
         );
-        let output: Array<any> = [];
-        if (options.format === 'human') {
+        if (options.format === 'json') {
+          process.stdout.write(binUtils.outputFormatter({
+            type: 'json',
+            data: resultOutput,
+          }));
+        }
+        else {
+          let output: Array<{
+            nodeId: string;
+            address: string;
+            bucketIndex: number;
+          }> = [];
           for (const nodesGetMessage of resultOutput) {
             const nodeIdEncoded = nodesGetMessage.nodeIdEncoded;
             const bucketIndex = nodesGetMessage.bucketIndex;
             for (const address of Object.keys(nodesGetMessage.nodeContact)) {
-              output.push(
-                `NodeId ${nodeIdEncoded}, Address ${address}, bucketIndex ${bucketIndex}`,
-              );
+              output.push({
+                nodeId: nodeIdEncoded,
+                address,
+                bucketIndex,
+              });
             }
           }
-        } else {
-          output = resultOutput;
+          process.stdout.write(binUtils.outputFormatter({
+            type: 'table',
+            options: {
+              columns: [
+                "nodeId",
+                "address",
+                "bucketIndex",
+              ]
+            },
+            data: output,
+          }));
         }
-        const outputFormatted = binUtils.outputFormatter({
-          type: options.format === 'json' ? 'json' : 'list',
-          data: output,
-        });
-        process.stdout.write(outputFormatted);
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/nodes/CommandGetAll.ts
+++ b/src/nodes/CommandGetAll.ts
@@ -58,13 +58,14 @@ class CommandGetAll extends CommandPolykey {
           auth,
         );
         if (options.format === 'json') {
-          process.stdout.write(binUtils.outputFormatter({
-            type: 'json',
-            data: resultOutput,
-          }));
-        }
-        else {
-          let output: Array<{
+          process.stdout.write(
+            binUtils.outputFormatter({
+              type: 'json',
+              data: resultOutput,
+            }),
+          );
+        } else {
+          const output: Array<{
             nodeId: string;
             address: string;
             bucketIndex: number;
@@ -80,17 +81,15 @@ class CommandGetAll extends CommandPolykey {
               });
             }
           }
-          process.stdout.write(binUtils.outputFormatter({
-            type: 'table',
-            options: {
-              columns: [
-                "nodeId",
-                "address",
-                "bucketIndex",
-              ]
-            },
-            data: output,
-          }));
+          process.stdout.write(
+            binUtils.outputFormatter({
+              type: 'table',
+              options: {
+                columns: ['nodeId', 'address', 'bucketIndex'],
+              },
+              data: output,
+            }),
+          );
         }
       } finally {
         if (pkClient! != null) await pkClient.stop();

--- a/src/nodes/CommandPing.ts
+++ b/src/nodes/CommandPing.ts
@@ -57,23 +57,19 @@ class CommandPing extends CommandPolykey {
             }),
           auth,
         );
-        const status = { success: false, message: '' };
-        status.success = statusMessage ? statusMessage.success : false;
-        if (!status.success && !error) {
+        if (!statusMessage.success) {
           error = new errors.ErrorPolykeyCLINodePingFailed(
             'No response received',
           );
         }
-        if (status.success) status.message = 'Node is Active.';
-        else status.message = error.message;
-        const output: any =
-          options.format === 'json' ? status : [status.message];
+        if (statusMessage.success) process.stderr.write('Node is Active\n');
         const outputFormatted = binUtils.outputFormatter({
-          type: options.format === 'json' ? 'json' : 'list',
-          data: output,
+          type: options.format === 'json' ? 'json' : 'dict',
+          data: {
+            success: statusMessage.success,
+          },
         });
         process.stdout.write(outputFormatted);
-
         if (error != null) throw error;
       } finally {
         if (pkClient! != null) await pkClient.stop();

--- a/src/notifications/CommandRead.ts
+++ b/src/notifications/CommandRead.ts
@@ -99,7 +99,9 @@ class CommandRead extends CommandPolykey {
             process.stdout.write(
               binUtils.outputFormatter({
                 type: 'dict',
-                data: notificationReadMessage.notification,
+                data: {
+                  notificiation: notificationReadMessage.notification,
+                },
               }),
             );
           }

--- a/src/notifications/CommandRead.ts
+++ b/src/notifications/CommandRead.ts
@@ -61,7 +61,7 @@ class CommandRead extends CommandPolykey {
           },
           logger: this.logger.getChild(PolykeyClient.name),
         });
-        const notifications = await binUtils.retryAuthentication(
+        const notificationReadMessages = await binUtils.retryAuthentication(
           async (auth) => {
             const response = await pkClient.rpcClient.methods.notificationsRead(
               {
@@ -71,33 +71,35 @@ class CommandRead extends CommandPolykey {
                 order: options.order,
               },
             );
-            const notifications: Array<Notification> = [];
+            const notificationReadMessages: Array<{
+              notification: Notification;
+            }> = [];
             for await (const notificationMessage of response) {
               const notification = notificationsUtils.parseNotification(
                 notificationMessage.notification,
               );
-              notifications.push(notification);
+              notificationReadMessages.push({ notification });
             }
-            return notifications;
+            return notificationReadMessages;
           },
           meta,
         );
-        if (notifications.length === 0) {
+        if (notificationReadMessages.length === 0) {
           process.stderr.write('No notifications received\n');
         }
         if (options.format === 'json') {
           process.stdout.write(
             binUtils.outputFormatter({
               type: 'json',
-              data: notifications,
+              data: notificationReadMessages,
             }),
           );
         } else {
-          for (const notification of notifications) {
+          for (const notificationReadMessage of notificationReadMessages) {
             process.stdout.write(
               binUtils.outputFormatter({
                 type: 'dict',
-                data: notification,
+                data: notificationReadMessage.notification,
               }),
             );
           }

--- a/src/notifications/CommandRead.ts
+++ b/src/notifications/CommandRead.ts
@@ -82,12 +82,25 @@ class CommandRead extends CommandPolykey {
           },
           meta,
         );
-        for (const notification of notifications) {
-          const outputFormatted = binUtils.outputFormatter({
-            type: options.format === 'json' ? 'json' : 'dict',
-            data: notification,
-          });
-          process.stdout.write(outputFormatted);
+        if (notifications.length === 0) {
+          process.stderr.write('No notifications received\n');
+        }
+        if (options.format === 'json') {
+          process.stdout.write(
+            binUtils.outputFormatter({
+              type: 'json',
+              data: notifications,
+            }),
+          );
+        } else {
+          for (const notification of notifications) {
+            process.stdout.write(
+              binUtils.outputFormatter({
+                type: 'dict',
+                data: notification,
+              }),
+            );
+          }
         }
       } finally {
         if (pkClient! != null) await pkClient.stop();

--- a/src/secrets/CommandGet.ts
+++ b/src/secrets/CommandGet.ts
@@ -59,11 +59,23 @@ class CommandGet extends CommandPolykey {
           meta,
         );
         const secretContent = Buffer.from(response.secretContent, 'binary');
-        const outputFormatted = binUtils.outputFormatter({
-          type: 'raw',
-          data: secretContent,
-        });
-        process.stdout.write(outputFormatted);
+        if (options.format === 'json') {
+          process.stdout.write(
+            binUtils.outputFormatter({
+              type: 'json',
+              data: {
+                secretContent: secretContent.toString(),
+              },
+            }),
+          );
+        } else {
+          process.stdout.write(
+            binUtils.outputFormatter({
+              type: 'raw',
+              data: secretContent,
+            }),
+          );
+        }
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/secrets/CommandStat.ts
+++ b/src/secrets/CommandStat.ts
@@ -60,18 +60,23 @@ class CommandStat extends CommandPolykey {
           meta,
         );
 
-        const data: Array<string> = [`Stats for "${secretPath[1]}"`];
-        for (const [key, value] of Object.entries(response.stat)) {
-          data.push(`${key}: ${value}`);
+        if (options.format === 'json') {
+          process.stdout.write(
+            binUtils.outputFormatter({
+              type: 'json',
+              data: {
+                stat: response.stat,
+              },
+            }),
+          );
+        } else {
+          process.stdout.write(
+            binUtils.outputFormatter({
+              type: 'dict',
+              data: response.stat,
+            }),
+          );
         }
-
-        // Assuming the surrounding function is async
-        const outputFormatted = binUtils.outputFormatter({
-          type: options.format === 'json' ? 'json' : 'list',
-          data,
-        });
-
-        process.stdout.write(outputFormatted);
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,10 @@ interface TableOptions {
   includeRowCount?: boolean;
 }
 
+interface DictOptions {
+  padding?: number;
+}
+
 type AgentStatusLiveData = Omit<StatusLive['data'], 'nodeId'> & {
   nodeId: NodeIdEncoded;
 };
@@ -51,6 +55,7 @@ type AgentChildProcessOutput =
 export type {
   TableRow,
   TableOptions,
+  DictOptions,
   AgentStatusLiveData,
   AgentChildProcessInput,
   AgentChildProcessOutput,

--- a/src/vaults/CommandCreate.ts
+++ b/src/vaults/CommandCreate.ts
@@ -54,11 +54,9 @@ class CommandCreate extends CommandPolykey {
             }),
           meta,
         );
-        const outputFormatted = binUtils.outputFormatter({
-          type: options.format === 'json' ? 'json' : 'list',
-          data: [`Vault ${response.vaultIdEncoded} created successfully`],
-        });
-        process.stdout.write(outputFormatted);
+        process.stderr.write(
+          `Vault ${response.vaultIdEncoded} created successfully`,
+        );
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/vaults/CommandCreate.ts
+++ b/src/vaults/CommandCreate.ts
@@ -55,7 +55,7 @@ class CommandCreate extends CommandPolykey {
           meta,
         );
         process.stderr.write(
-          `Vault ${response.vaultIdEncoded} created successfully`,
+          `Vault ${response.vaultIdEncoded} created successfully\n`,
         );
       } finally {
         if (pkClient! != null) await pkClient.stop();

--- a/src/vaults/CommandPermissions.ts
+++ b/src/vaults/CommandPermissions.ts
@@ -80,10 +80,8 @@ class CommandPermissions extends CommandPolykey {
           process.stdout.write(
             binUtils.outputFormatter({
               type: 'dict',
-              data: data.map((permission: any) => {
-                delete permission.vaultIdEncoded;
-                permission.actions = permission.vaultPermissionList.join(',');
-                delete permission.vaultPermissionList;
+              data: data.map((permission) => {
+                permission.vaultPermissionList = permission.vaultPermissionList.join(',') as any;
                 return permission;
               }),
             }),

--- a/src/vaults/CommandPermissions.ts
+++ b/src/vaults/CommandPermissions.ts
@@ -45,7 +45,11 @@ class CommandPermissions extends CommandPolykey {
           },
           logger: this.logger.getChild(PolykeyClient.name),
         });
-        const data: Array<string> = [];
+        const data: Array<{
+          vaultIdEncoded: string;
+          nodeIdEncoded: string;
+          vaultPermissionList: Array<string>;
+        }> = [];
         await binUtils.retryAuthentication(async (auth) => {
           const permissionStream =
             await pkClient.rpcClient.methods.vaultsPermissionGet({
@@ -53,19 +57,38 @@ class CommandPermissions extends CommandPolykey {
               nameOrId: vaultName,
             });
           for await (const permission of permissionStream) {
-            const nodeId = permission.nodeIdEncoded;
-            const actions = permission.vaultPermissionList.join(', ');
-            data.push(`${nodeId}: ${actions}`);
+            data.push({
+              vaultIdEncoded: permission.vaultIdEncoded,
+              nodeIdEncoded: permission.nodeIdEncoded,
+              vaultPermissionList: permission.vaultPermissionList,
+            });
           }
           return true;
         }, meta);
 
-        if (data.length === 0) data.push('No permissions were found');
-        const outputFormatted = binUtils.outputFormatter({
-          type: options.format === 'json' ? 'json' : 'list',
-          data: data,
-        });
-        process.stdout.write(outputFormatted);
+        if (data.length === 0) {
+          process.stderr.write('No permissions were found\n');
+        }
+        if (options.format === 'json') {
+          process.stdout.write(
+            binUtils.outputFormatter({
+              type: 'json',
+              data: data,
+            }),
+          );
+        } else {
+          process.stdout.write(
+            binUtils.outputFormatter({
+              type: 'dict',
+              data: data.map((permission: any) => {
+                delete permission.vaultIdEncoded;
+                permission.actions = permission.vaultPermissionList.join(',');
+                delete permission.vaultPermissionList;
+                return permission;
+              }),
+            }),
+          );
+        }
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/vaults/CommandPermissions.ts
+++ b/src/vaults/CommandPermissions.ts
@@ -81,7 +81,8 @@ class CommandPermissions extends CommandPolykey {
             binUtils.outputFormatter({
               type: 'dict',
               data: data.map((permission) => {
-                permission.vaultPermissionList = permission.vaultPermissionList.join(',') as any;
+                permission.vaultPermissionList =
+                  permission.vaultPermissionList.join(',') as any;
                 return permission;
               }),
             }),

--- a/src/vaults/CommandPermissions.ts
+++ b/src/vaults/CommandPermissions.ts
@@ -77,16 +77,16 @@ class CommandPermissions extends CommandPolykey {
             }),
           );
         } else {
-          process.stdout.write(
-            binUtils.outputFormatter({
-              type: 'dict',
-              data: data.map((permission) => {
-                permission.vaultPermissionList =
-                  permission.vaultPermissionList.join(',') as any;
-                return permission;
+          for (const permission of data) {
+            permission.vaultPermissionList =
+              permission.vaultPermissionList.join(',') as any;
+            process.stdout.write(
+              binUtils.outputFormatter({
+                type: 'dict',
+                data: permission,
               }),
-            }),
-          );
+            );
+          }
         }
       } finally {
         if (pkClient! != null) await pkClient.stop();

--- a/tests/agent/stop.test.ts
+++ b/tests/agent/stop.test.ts
@@ -220,7 +220,7 @@ describe('stop', () => {
         },
       );
       testUtils.expectProcessError(exitCode, stderr, [
-        new binErrors.ErrorPolykeyCLIAgentStatus('agent is starting'),
+        new binErrors.ErrorPolykeyCLIAgentStatus('Agent is starting'),
       ]);
       await status.waitFor('LIVE');
       await testUtils.pkStdio(['agent', 'stop'], {

--- a/tests/identities/allowDisallowPermissions.test.ts
+++ b/tests/identities/allowDisallowPermissions.test.ts
@@ -164,7 +164,7 @@ describe('allow/disallow/permissions', () => {
     ));
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout)).toEqual({
-      permissions: ['notify', 'scan'],
+      actionsList: ['notify', 'scan'],
     });
     // Disallow both permissions
     ({ exitCode } = await testUtils.pkStdio(
@@ -208,7 +208,7 @@ describe('allow/disallow/permissions', () => {
     ));
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout)).toEqual({
-      permissions: [],
+      actionsList: [],
     });
   });
   test('allows/disallows/gets gestalt permissions by identity', async () => {
@@ -299,7 +299,7 @@ describe('allow/disallow/permissions', () => {
     ));
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout)).toEqual({
-      permissions: ['notify', 'scan'],
+      actionsList: ['notify', 'scan'],
     });
     // Disallow both permissions
     ({ exitCode } = await testUtils.pkStdio(
@@ -337,7 +337,7 @@ describe('allow/disallow/permissions', () => {
     ));
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout)).toEqual({
-      permissions: [],
+      actionsList: [],
     });
   });
   test('should fail on invalid inputs', async () => {

--- a/tests/identities/claim.test.ts
+++ b/tests/identities/claim.test.ts
@@ -92,7 +92,10 @@ describe('claim', () => {
       },
     );
     expect(exitCode).toBe(0);
-    expect(JSON.parse(stdout)).toEqual(['Claim Id: 0', 'Url: test.com']);
+    expect(JSON.parse(stdout)).toEqual({
+      claimId: '0',
+      url: 'test.com',
+    });
     // Check for claim on the provider
     const claim = await testProvider.getClaim(
       testToken.identityId,

--- a/tests/identities/trustUntrustList.test.ts
+++ b/tests/identities/trustUntrustList.test.ts
@@ -172,15 +172,21 @@ describe('trust/untrust/list', () => {
       ));
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toHaveLength(2);
-      expect(JSON.parse(stdout)[0]).toEqual({
-        permissions: ['notify'],
-        nodes: [{ nodeId: nodesUtils.encodeNodeId(nodeId) }],
-        identities: [
-          {
-            providerId: provider.id,
-            identityId: identity,
+      expect(JSON.parse(stdout)[0]).toMatchObject({
+        gestalt: {
+          actionsList: ['notify'],
+          nodes: {
+            ['node-' + nodesUtils.encodeNodeId(nodeId)]: {
+              nodeId: nodesUtils.encodeNodeId(nodeId),
+            },
           },
-        ],
+          identities: {
+            ['identity-' + JSON.stringify([provider.id, identity])]: {
+              providerId: provider.id,
+              identityId: identity,
+            },
+          },
+        },
       });
       // Untrust the gestalt by node
       // This should remove the permission, but not the gestalt (from the gestalt
@@ -209,15 +215,21 @@ describe('trust/untrust/list', () => {
       ));
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toHaveLength(2);
-      expect(JSON.parse(stdout)[0]).toEqual({
-        permissions: null,
-        nodes: [{ nodeId: nodesUtils.encodeNodeId(nodeId) }],
-        identities: [
-          {
-            providerId: provider.id,
-            identityId: identity,
+      expect(JSON.parse(stdout)[0]).toMatchObject({
+        gestalt: {
+          actionsList: [],
+          nodes: {
+            ['node-' + nodesUtils.encodeNodeId(nodeId)]: {
+              nodeId: nodesUtils.encodeNodeId(nodeId),
+            },
           },
-        ],
+          identities: {
+            ['identity-' + JSON.stringify([provider.id, identity])]: {
+              providerId: provider.id,
+              identityId: identity,
+            },
+          },
+        },
       });
       // Revert side-effects
       await pkAgent.gestaltGraph.unsetNode(nodeId);
@@ -316,15 +328,21 @@ describe('trust/untrust/list', () => {
       ));
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toHaveLength(2);
-      expect(JSON.parse(stdout)[0]).toEqual({
-        permissions: ['notify'],
-        nodes: [{ nodeId: nodesUtils.encodeNodeId(nodeId) }],
-        identities: [
-          {
-            providerId: provider.id,
-            identityId: identity,
+      expect(JSON.parse(stdout)[0]).toMatchObject({
+        gestalt: {
+          actionsList: ['notify'],
+          nodes: {
+            ['node-' + nodesUtils.encodeNodeId(nodeId)]: {
+              nodeId: nodesUtils.encodeNodeId(nodeId),
+            },
           },
-        ],
+          identities: {
+            ['identity-' + JSON.stringify([provider.id, identity])]: {
+              providerId: provider.id,
+              identityId: identity,
+            },
+          },
+        },
       });
       // Untrust the gestalt by node
       // This should remove the permission, but not the gestalt (from the gestalt
@@ -353,15 +371,21 @@ describe('trust/untrust/list', () => {
       ));
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toHaveLength(2);
-      expect(JSON.parse(stdout)[0]).toEqual({
-        permissions: null,
-        nodes: [{ nodeId: nodesUtils.encodeNodeId(nodeId) }],
-        identities: [
-          {
-            providerId: provider.id,
-            identityId: identity,
+      expect(JSON.parse(stdout)[0]).toMatchObject({
+        gestalt: {
+          actionsList: [],
+          nodes: {
+            ['node-' + nodesUtils.encodeNodeId(nodeId)]: {
+              nodeId: nodesUtils.encodeNodeId(nodeId),
+            },
           },
-        ],
+          identities: {
+            ['identity-' + JSON.stringify([provider.id, identity])]: {
+              providerId: provider.id,
+              identityId: identity,
+            },
+          },
+        },
       });
       // Revert side-effects
       await pkAgent.gestaltGraph.unsetNode(nodeId);

--- a/tests/keys/certchain.test.ts
+++ b/tests/keys/certchain.test.ts
@@ -27,8 +27,6 @@ describe('certchain', () => {
       },
     );
     expect(exitCode).toBe(0);
-    expect(JSON.parse(stdout)).toEqual({
-      certchain: expect.any(Array),
-    });
+    expect(JSON.parse(stdout)).toEqual(expect.any(Array));
   });
 });

--- a/tests/keys/encryptDecrypt.test.ts
+++ b/tests/keys/encryptDecrypt.test.ts
@@ -44,7 +44,7 @@ describe('encrypt-decrypt', () => {
     );
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout)).toEqual({
-      decryptedData: 'abc',
+      data: 'abc',
     });
   });
   test('encrypts data using NodeId', async () => {
@@ -74,9 +74,9 @@ describe('encrypt-decrypt', () => {
     );
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout)).toEqual({
-      encryptedData: expect.any(String),
+      data: expect.any(String),
     });
-    const encrypted = JSON.parse(stdout).encryptedData;
+    const encrypted = JSON.parse(stdout).data;
     const decrypted = keysUtils.decryptWithPrivateKey(
       targetKeyPair,
       Buffer.from(encrypted, 'binary'),
@@ -105,9 +105,9 @@ describe('encrypt-decrypt', () => {
     );
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout)).toEqual({
-      encryptedData: expect.any(String),
+      data: expect.any(String),
     });
-    const encrypted = JSON.parse(stdout).encryptedData;
+    const encrypted = JSON.parse(stdout).data;
     const decrypted = keysUtils.decryptWithPrivateKey(
       targetKeyPair,
       Buffer.from(encrypted, 'binary'),

--- a/tests/keys/keypair.test.ts
+++ b/tests/keys/keypair.test.ts
@@ -29,7 +29,7 @@ describe('keypair', () => {
     );
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout)).toEqual({
-      publicKey: {
+      publicKeyJwk: {
         alg: expect.any(String),
         crv: expect.any(String),
         ext: expect.any(Boolean),
@@ -37,7 +37,7 @@ describe('keypair', () => {
         kty: expect.any(String),
         x: expect.any(String),
       },
-      privateKey: {
+      privateKeyJwe: {
         ciphertext: expect.any(String),
         iv: expect.any(String),
         protected: expect.any(String),

--- a/tests/keys/renew.test.ts
+++ b/tests/keys/renew.test.ts
@@ -55,8 +55,8 @@ describe('renew', () => {
       },
     );
     expect(exitCode).toBe(0);
-    const prevPublicKey = JSON.parse(stdout).publicKey;
-    const prevPrivateKey = JSON.parse(stdout).privateKey;
+    const prevPublicKey = JSON.parse(stdout).publicKeyJwk;
+    const prevPrivateKey = JSON.parse(stdout).privateKeyJwe;
     ({ exitCode, stdout } = await testUtils.pkStdio(
       ['agent', 'status', '--format', 'json'],
       {
@@ -103,8 +103,8 @@ describe('renew', () => {
       },
     ));
     expect(exitCode).toBe(0);
-    const newPublicKey = JSON.parse(stdout).publicKey;
-    const newPrivateKey = JSON.parse(stdout).privateKey;
+    const newPublicKey = JSON.parse(stdout).publicKeyJwk;
+    const newPrivateKey = JSON.parse(stdout).privateKeyJwe;
     ({ exitCode, stdout } = await testUtils.pkStdio(
       ['agent', 'status', '--format', 'json'],
       {

--- a/tests/keys/reset.test.ts
+++ b/tests/keys/reset.test.ts
@@ -55,8 +55,8 @@ describe('reset', () => {
       },
     );
     expect(exitCode).toBe(0);
-    const prevPublicKey = JSON.parse(stdout).publicKey;
-    const prevPrivateKey = JSON.parse(stdout).privateKey;
+    const prevPublicKey = JSON.parse(stdout).publicKeyJwk;
+    const prevPrivateKey = JSON.parse(stdout).privateKeyJwe;
     ({ exitCode, stdout } = await testUtils.pkStdio(
       ['agent', 'status', '--format', 'json'],
       {
@@ -104,8 +104,8 @@ describe('reset', () => {
       },
     ));
     expect(exitCode).toBe(0);
-    const newPublicKey = JSON.parse(stdout).publicKey;
-    const newPrivateKey = JSON.parse(stdout).privateKey;
+    const newPublicKey = JSON.parse(stdout).publicKeyJwk;
+    const newPrivateKey = JSON.parse(stdout).privateKeyJwe;
     ({ exitCode, stdout } = await testUtils.pkStdio(
       ['agent', 'status', '--format', 'json'],
       {

--- a/tests/keys/signVerify.test.ts
+++ b/tests/keys/signVerify.test.ts
@@ -88,7 +88,7 @@ describe('sign-verify', () => {
     );
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout)).toEqual({
-      signatureVerified: true,
+      success: true,
     });
   });
   test('verifies a signature with JWK', async () => {
@@ -122,7 +122,7 @@ describe('sign-verify', () => {
     );
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout)).toEqual({
-      signatureVerified: true,
+      success: true,
     });
   });
   test('verifies a signature fails with invalid JWK', async () => {

--- a/tests/nodes/claim.test.ts
+++ b/tests/nodes/claim.test.ts
@@ -81,8 +81,8 @@ describe('claim', () => {
     });
   });
   test('sends a gestalt invite', async () => {
-    const { exitCode, stdout } = await testUtils.pkStdio(
-      ['nodes', 'claim', remoteIdEncoded],
+    const { exitCode, stdout, stderr } = await testUtils.pkStdio(
+      ['nodes', 'claim', remoteIdEncoded, '--format', 'json'],
       {
         env: {
           PK_NODE_PATH: nodePath,
@@ -92,15 +92,15 @@ describe('claim', () => {
       },
     );
     expect(exitCode).toBe(0);
-    expect(stdout).toContain('Successfully generated a cryptolink claim');
-    expect(stdout).toContain(remoteIdEncoded);
+    expect(JSON.parse(stdout)).toMatchObject({ success: true });
+    expect(stderr).toContain(remoteIdEncoded);
   });
   test('sends a gestalt invite (force invite)', async () => {
     await remoteNode.notificationsManager.sendNotification(localId, {
       type: 'GestaltInvite',
     });
-    const { exitCode, stdout } = await testUtils.pkStdio(
-      ['nodes', 'claim', remoteIdEncoded, '--force-invite'],
+    const { exitCode, stdout, stderr } = await testUtils.pkStdio(
+      ['nodes', 'claim', remoteIdEncoded, '--force-invite', '--format', 'json'],
       {
         env: {
           PK_NODE_PATH: nodePath,
@@ -110,15 +110,15 @@ describe('claim', () => {
       },
     );
     expect(exitCode).toBe(0);
-    expect(stdout).toContain('Successfully generated a cryptolink');
-    expect(stdout).toContain(nodesUtils.encodeNodeId(remoteId));
+    expect(JSON.parse(stdout)).toMatchObject({ success: true });
+    expect(stderr).toContain(nodesUtils.encodeNodeId(remoteId));
   });
   test('claims a node', async () => {
     await remoteNode.notificationsManager.sendNotification(localId, {
       type: 'GestaltInvite',
     });
-    const { exitCode, stdout } = await testUtils.pkStdio(
-      ['nodes', 'claim', remoteIdEncoded],
+    const { exitCode, stdout, stderr } = await testUtils.pkStdio(
+      ['nodes', 'claim', remoteIdEncoded, '--format', 'json'],
       {
         env: {
           PK_NODE_PATH: nodePath,
@@ -128,7 +128,7 @@ describe('claim', () => {
       },
     );
     expect(exitCode).toBe(0);
-    expect(stdout).toContain('cryptolink claim');
-    expect(stdout).toContain(remoteIdEncoded);
+    expect(JSON.parse(stdout)).toMatchObject({ success: true });
+    expect(stderr).toContain(remoteIdEncoded);
   });
 });

--- a/tests/nodes/find.test.ts
+++ b/tests/nodes/find.test.ts
@@ -98,7 +98,7 @@ describe('find', () => {
     });
   });
   test('finds an online node', async () => {
-    const { exitCode, stdout } = await testUtils.pkStdio(
+    const { exitCode, stdout, stderr } = await testUtils.pkStdio(
       [
         'nodes',
         'find',
@@ -117,14 +117,11 @@ describe('find', () => {
     expect(exitCode).toBe(0);
     const output = JSON.parse(stdout);
     expect(output).toMatchObject({
-      success: true,
-      id: nodesUtils.encodeNodeId(remoteOnlineNodeId),
+      nodeAddress: expect.any(Object),
+      nodeContactAddressData: expect.any(Object),
     });
-    expect(output.address).toMatchObject({
-      host: remoteOnlineHost,
-      port: remoteOnlinePort,
-    });
-    expect(output.message).toMatch(
+    expect(output.nodeAddress).toEqual([remoteOnlineHost, remoteOnlinePort]);
+    expect(stderr).toMatch(
       new RegExp(`Found node at .*?${remoteOnlineHost}:${remoteOnlinePort}.*?`),
     );
   });
@@ -135,7 +132,7 @@ describe('find', () => {
       const unknownNodeId = nodesUtils.decodeNodeId(
         'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg',
       );
-      const { exitCode, stdout } = await testUtils.pkStdio(
+      const { exitCode, stderr } = await testUtils.pkExec(
         [
           'nodes',
           'find',
@@ -152,13 +149,7 @@ describe('find', () => {
         },
       );
       expect(exitCode).toBe(sysexits.GENERAL);
-      expect(JSON.parse(stdout)).toEqual({
-        success: false,
-        message: `Failed to find node ${nodesUtils.encodeNodeId(
-          unknownNodeId!,
-        )}`,
-        id: nodesUtils.encodeNodeId(unknownNodeId!),
-      });
+      expect(JSON.parse(stderr).type).toBe('ErrorPolykeyCLINodeFindFailed');
     },
     globalThis.failedConnectionTimeout,
   );

--- a/tests/nodes/ping.test.ts
+++ b/tests/nodes/ping.test.ts
@@ -106,7 +106,6 @@ describe('ping', () => {
       expect(stderr).toContain('No response received');
       expect(JSON.parse(stdout)).toEqual({
         success: false,
-        message: 'No response received',
       });
     },
     globalThis.failedConnectionTimeout,
@@ -136,13 +135,12 @@ describe('ping', () => {
       expect(exitCode).not.toBe(0); // Should fail if node doesn't exist.
       expect(JSON.parse(stdout)).toEqual({
         success: false,
-        message: `No response received`,
       });
     },
     globalThis.failedConnectionTimeout,
   );
   test('succeed when pinging a live node', async () => {
-    const { exitCode, stdout } = await testUtils.pkStdio(
+    const { exitCode, stdout, stderr } = await testUtils.pkStdio(
       [
         'nodes',
         'ping',
@@ -161,7 +159,7 @@ describe('ping', () => {
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout)).toEqual({
       success: true,
-      message: 'Node is Active.',
     });
+    expect(stderr).toContain('Node is Active');
   });
 });

--- a/tests/notifications/sendReadClear.test.ts
+++ b/tests/notifications/sendReadClear.test.ts
@@ -173,10 +173,7 @@ describe('send/read/claim', () => {
         },
       ));
       expect(exitCode).toBe(0);
-      readNotifications = stdout
-        .split('\n')
-        .slice(undefined, -1)
-        .map((v) => JSON.parse(v));
+      readNotifications = JSON.parse(stdout);
       expect(readNotifications).toHaveLength(3);
       expect(readNotifications[0]).toMatchObject({
         data: {
@@ -217,10 +214,7 @@ describe('send/read/claim', () => {
         },
       ));
       expect(exitCode).toBe(0);
-      readNotifications = stdout
-        .split('\n')
-        .slice(undefined, -1)
-        .map((v) => JSON.parse(v));
+      readNotifications = JSON.parse(stdout);
       expect(readNotifications).toHaveLength(0);
       // Read notifications on reverse order
       ({ exitCode, stdout } = await testUtils.pkExec(
@@ -234,10 +228,7 @@ describe('send/read/claim', () => {
         },
       ));
       expect(exitCode).toBe(0);
-      readNotifications = stdout
-        .split('\n')
-        .slice(undefined, -1)
-        .map((v) => JSON.parse(v));
+      readNotifications = JSON.parse(stdout);
       expect(readNotifications).toHaveLength(3);
       expect(readNotifications[0]).toMatchObject({
         data: {
@@ -278,10 +269,7 @@ describe('send/read/claim', () => {
         },
       ));
       expect(exitCode).toBe(0);
-      readNotifications = stdout
-        .split('\n')
-        .slice(undefined, -1)
-        .map((v) => JSON.parse(v));
+      readNotifications = JSON.parse(stdout);
       expect(readNotifications).toHaveLength(1);
       expect(readNotifications[0]).toMatchObject({
         data: {
@@ -312,10 +300,7 @@ describe('send/read/claim', () => {
         },
       ));
       expect(exitCode).toBe(0);
-      readNotifications = stdout
-        .split('\n')
-        .slice(undefined, -1)
-        .map((v) => JSON.parse(v));
+      readNotifications = JSON.parse(stdout);
       expect(readNotifications).toHaveLength(0);
     },
     globalThis.defaultTimeout * 3,

--- a/tests/notifications/sendReadClear.test.ts
+++ b/tests/notifications/sendReadClear.test.ts
@@ -63,7 +63,7 @@ describe('send/read/claim', () => {
     'sends, receives, and clears notifications',
     async () => {
       let exitCode: number, stdout: string;
-      let readNotifications: Array<Notification>;
+      let readNotificationMessages: Array<{ notification: Notification }>;
       // Add receiver to sender's node graph, so it can be contacted
       ({ exitCode } = await testUtils.pkExec(
         [
@@ -173,9 +173,9 @@ describe('send/read/claim', () => {
         },
       ));
       expect(exitCode).toBe(0);
-      readNotifications = JSON.parse(stdout);
-      expect(readNotifications).toHaveLength(3);
-      expect(readNotifications[0]).toMatchObject({
+      readNotificationMessages = JSON.parse(stdout);
+      expect(readNotificationMessages).toHaveLength(3);
+      expect(readNotificationMessages[0].notification).toMatchObject({
         data: {
           type: 'General',
           message: 'test message 3',
@@ -184,7 +184,7 @@ describe('send/read/claim', () => {
         sub: nodesUtils.encodeNodeId(receiverId),
         isRead: true,
       });
-      expect(readNotifications[1]).toMatchObject({
+      expect(readNotificationMessages[1].notification).toMatchObject({
         data: {
           type: 'General',
           message: 'test message 2',
@@ -193,7 +193,7 @@ describe('send/read/claim', () => {
         sub: nodesUtils.encodeNodeId(receiverId),
         isRead: true,
       });
-      expect(readNotifications[2]).toMatchObject({
+      expect(readNotificationMessages[2].notification).toMatchObject({
         data: {
           type: 'General',
           message: 'test message 1',
@@ -214,8 +214,8 @@ describe('send/read/claim', () => {
         },
       ));
       expect(exitCode).toBe(0);
-      readNotifications = JSON.parse(stdout);
-      expect(readNotifications).toHaveLength(0);
+      readNotificationMessages = JSON.parse(stdout);
+      expect(readNotificationMessages).toHaveLength(0);
       // Read notifications on reverse order
       ({ exitCode, stdout } = await testUtils.pkExec(
         ['notifications', 'read', '--order=oldest', '--format', 'json'],
@@ -228,9 +228,9 @@ describe('send/read/claim', () => {
         },
       ));
       expect(exitCode).toBe(0);
-      readNotifications = JSON.parse(stdout);
-      expect(readNotifications).toHaveLength(3);
-      expect(readNotifications[0]).toMatchObject({
+      readNotificationMessages = JSON.parse(stdout);
+      expect(readNotificationMessages).toHaveLength(3);
+      expect(readNotificationMessages[0].notification).toMatchObject({
         data: {
           type: 'General',
           message: 'test message 1',
@@ -239,7 +239,7 @@ describe('send/read/claim', () => {
         sub: nodesUtils.encodeNodeId(receiverId),
         isRead: true,
       });
-      expect(readNotifications[1]).toMatchObject({
+      expect(readNotificationMessages[1].notification).toMatchObject({
         data: {
           type: 'General',
           message: 'test message 2',
@@ -248,7 +248,7 @@ describe('send/read/claim', () => {
         sub: nodesUtils.encodeNodeId(receiverId),
         isRead: true,
       });
-      expect(readNotifications[2]).toMatchObject({
+      expect(readNotificationMessages[2].notification).toMatchObject({
         data: {
           type: 'General',
           message: 'test message 3',
@@ -269,9 +269,9 @@ describe('send/read/claim', () => {
         },
       ));
       expect(exitCode).toBe(0);
-      readNotifications = JSON.parse(stdout);
-      expect(readNotifications).toHaveLength(1);
-      expect(readNotifications[0]).toMatchObject({
+      readNotificationMessages = JSON.parse(stdout);
+      expect(readNotificationMessages).toHaveLength(1);
+      expect(readNotificationMessages[0].notification).toMatchObject({
         data: {
           type: 'General',
           message: 'test message 3',
@@ -300,8 +300,8 @@ describe('send/read/claim', () => {
         },
       ));
       expect(exitCode).toBe(0);
-      readNotifications = JSON.parse(stdout);
-      expect(readNotifications).toHaveLength(0);
+      readNotificationMessages = JSON.parse(stdout);
+      expect(readNotificationMessages).toHaveLength(0);
     },
     globalThis.defaultTimeout * 3,
   );

--- a/tests/secrets/stat.test.ts
+++ b/tests/secrets/stat.test.ts
@@ -59,16 +59,28 @@ describe('commandStat', () => {
       await vaultOps.addSecret(vault, 'MySecret', 'this is the secret');
     });
 
-    command = ['secrets', 'stat', '-np', dataDir, `${vaultName}:MySecret`];
+    command = [
+      'secrets',
+      'stat',
+      '-np',
+      dataDir,
+      `${vaultName}:MySecret`,
+      '--format',
+      'json',
+    ];
 
     const result = await testUtils.pkStdio([...command], {
       env: {},
       cwd: dataDir,
     });
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain('nlink: 1');
-    expect(result.stdout).toContain('blocks: 1');
-    expect(result.stdout).toContain('blksize: 4096');
-    expect(result.stdout).toContain('size: 18');
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      stat: {
+        nlink: 1,
+        blocks: 1,
+        blksize: 4096,
+        size: 18,
+      },
+    });
   });
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -119,6 +119,51 @@ describe('bin/utils', () => {
       }),
     ).toBe('{"key1":"value1","key2":"value2"}\n');
   });
+  test('dict nesting in human format', () => {
+    // Dict
+    expect(
+      binUtils.outputFormatter({
+        type: 'dict',
+        data: { key1: {}, key2: {} },
+      }),
+    ).toBe('key1\t\nkey2\t\n');
+    expect(
+      binUtils.outputFormatter({
+        type: 'dict',
+        data: { key1: ['value1', 'value2', 'value3'] },
+      }),
+    ).toBe('key1\t\n  value1\t\n  value2\t\n  value3\t\n');
+    expect(
+      binUtils.outputFormatter({
+        type: 'dict',
+        data: {
+          key1: {
+            key2: null,
+            key3: undefined,
+            key4: 'value',
+          },
+          key5: 'value',
+          key6: {
+            key7: {
+              key8: {
+                key9: 'value',
+              },
+            },
+          },
+        },
+      }),
+    ).toBe(
+      'key1\t\n' +
+        '  key2\t\n' +
+        '  key3\t\n' +
+        '  key4\tvalue\n' +
+        'key5\tvalue\n' +
+        'key6\t\n' +
+        '  key7\t\n' +
+        '    key8\t\n' +
+        '      key9\tvalue\n',
+    );
+  });
   test('outputFormatter should encode non-printable characters within a dict', () => {
     fc.assert(
       fc.property(


### PR DESCRIPTION
### Description
This PR fixes all the CLI stdout inconsistencies, this is kind of tedious and not critical at the moment though.

#### Changelog

- agent
  - CommandStatus - versionMetadata is no longer spread into parent object with JSON format. 
  - CommandBootstrap - Now uses dict format to output the recoveryCode.
- identities
  - CommandAuthenticate - Now uses dict format
  - CommandClaim - Dict Output, JSON format is now of type `{ claimId: string; url?: string }`.
  - CommandInvite - Feedback is now moved to `logger.info` so that it goes to stderr
  - CommandList output should be reconsidered due to nested structure. *
  - CommandSearch and CommandGet need streamlining in terms of their output *
- keys
  - CommandCert - Uses dict format
  - CommandCertchain - The message at the start is no longer included.
  - CommandEncrypt - Raw format
  - CommandDecrypt - Raw format
  - CommandSign - now uses camelcase for non-json formats
  - CommandVerify - now uses camelcase for non-json formats
  - CommandPublic, Private, and Pair will need to have further consideration due to nested structure. *
- nodes
  - CommandClaim - Stderr feedback and stdout of success *

#### Dict Format

This PR also implements changes to the dict format that allows for nesting.

Changes made to commands with this:

`agent/CommandStatus`
```
status                  LIVE
pid                     90556
nodeId                  vq3pk7bip927v2ivk7457p5g7b4q3ad0jksqrkv9rfkhl31l1ukng
clientHost              ::1
clientPort              33179
agentHost               ::
agentPort               35454
upTime                  9
startTime               1711068204
connectionsActive       2
nodesTotal              8
version                 1.2.1-alpha.50-1-1
sourceVersion           1.2.1-alpha.50
stateVersion            1
networkVersion          1
versionMetadata  
  version               0.2.3
  commitHash            9275aa5d0d5470e9e586a6fbbdc8ca150c37e5aa
  libVersion            1.2.1-alpha.50-1-1
  libSourceVersion      1.2.1-alpha.50
  libStateVersion       1
  libNetworkVersion     1
```

`identities/CommandList`
```
gestalt
  actionsList       notify
  identities 
    github.com:amydevs
  nodeIds    
    vq3pk7bip927v2ivk7457p5g7b4q3ad0jksqrkv9rfkhl31l1ukng
gestalt
  actionsList       scan
  identities 
    github.com:amydevs
  nodeIds    
    vq3pk7bip927v2ivk7457p5g7b4q3ad0jksqrkv9rfkhl31l1ukng
```


`notificiations/CommandRead`
```
notificiation
  data  
    message test message 1
    type    General
  iat       1711063520.438
  isRead    true
  iss       vmqmqq9h4jgduaeifep1nko1j2uebgg0uh48sc4fl9upqdsijjmf0
  sub       voeo52qencdh720o084mlfpgb1st09vjca0ti9qvm6e0p19ma316g
  typ       notification
notificiation
  data  
    message test message 2
    type    General
  iat       1711063520.438
  isRead    true
  iss       vmqmqq9h4jgduaeifep1nko1j2uebgg0uh48sc4fl9upqdsijjmf0
  sub       voeo52qencdh720o084mlfpgb1st09vjca0ti9qvm6e0p19ma316g
  typ       notification
```

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Related #22 (doesn't implement verbosity options) 
* https://github.com/MatrixAI/Polykey-CLI/issues/158

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Fix all necessary `list` formatted outputs to just be strings.
- [x] 2. Fix all necessary `list` formatted outputs to just be `dicts`.
- [x] 3. Fix `json` formatted outputs to return structured POJO rather than just an array with the message itself.
- [x] 4. Implement nesting in `dict` format
- [x] 5. Fix related tests.

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
