### PR TITLE
DNS-SD and SRV Records are Now Used to Bootstrap Polykey Agents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "nexpect": "^0.6.0",
         "node-gyp-build": "^4.4.0",
         "nodemon": "^3.0.1",
-        "polykey": "^1.2.1-alpha.30",
+        "polykey": "^1.2.1-alpha.32",
         "prettier": "^3.0.0",
         "shelljs": "^0.8.5",
         "shx": "^0.3.4",
@@ -7469,9 +7469,9 @@
       }
     },
     "node_modules/polykey": {
-      "version": "1.2.1-alpha.30",
-      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.2.1-alpha.30.tgz",
-      "integrity": "sha512-yqdmVfB2RsS6QBWAvj8WXNDRt2USGdPRfpRSY9zX95m/epHDQtp7pUCkth16SYnUJTmWibPex7jeGuuQ6wePZA==",
+      "version": "1.2.1-alpha.32",
+      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.2.1-alpha.32.tgz",
+      "integrity": "sha512-xQRRWzZrsxHKF+l2xVzO3qK6Y4yTCUKz3lBbJq1AbC0TZdPbYg/jrhiK+L8kWcWDNGEVMjZaRYYwQUat5+gc+g==",
       "dev": true,
       "dependencies": {
         "@matrixai/async-cancellable": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@matrixai/errors": "^1.2.0",
     "@matrixai/logger": "^3.1.0",
     "commander": "^8.3.0",
-    "polykey": "^1.2.1-alpha.30",
+    "polykey": "^1.2.1-alpha.32",
     "threads": "^1.6.5",
     "@swc/core": "1.3.82",
     "@swc/jest": "^0.2.29",

--- a/src/agent/CommandStart.ts
+++ b/src/agent/CommandStart.ts
@@ -92,7 +92,16 @@ class CommandStart extends CommandPolykey {
       // Will be '[{...}, false]' if `--seed-nodes='...'`
       const [seedNodes, defaults] = options.seedNodes;
       let seedNodes_ = seedNodes;
-      if (defaults) seedNodes_ = { ...options.network, ...seedNodes };
+      if (defaults) {
+        try {
+          seedNodes_ = {
+            ...(await nodesUtils.resolveSeednodes(options.network)),
+            ...seedNodes,
+          };
+        } catch (e) {
+          this.logger.warn(e.message);
+        }
+      }
       const agentOptions: DeepPartial<PolykeyAgentOptions> = {
         nodePath: options.nodePath,
         clientServiceHost: options.clientHost,

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -119,7 +119,7 @@ const parsePort: (data: string) => Port = validateParserToArgParser(
   networkUtils.parsePort,
 );
 
-const parseNetwork: (data: string) => SeedNodes = validateParserToArgParser(
+const parseNetwork: (data: string) => Hostname = validateParserToArgParser(
   nodesUtils.parseNetwork,
 );
 


### PR DESCRIPTION
### Description

The `polykey agent start` command now uses DNS to find the the ports and hosts of seednodes to connect to.

### Issues Fixed

* Related https://github.com/MatrixAI/Polykey/issues/599
* Related https://github.com/MatrixAI/Polykey/pull/618
* Related https://github.com/MatrixAI/Polykey/pull/639

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Utilise new `nodesUtils.resolveSeednodes` utility function to find seednodes

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
