### PR TITLE
Fixes the vault cloning issue when trying to clone a vault with the same name as one already present

### DIFF
--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -153,6 +153,11 @@ const forceNodeAdd = new commander.Option(
   'Force adding node to nodeGraph',
 ).default(false);
 
+const overrideClone = new commander.Option(
+  '--override',
+  'Force clone node and append with a _1',
+).default(false);
+
 const noPing = new commander.Option('--no-ping', 'Skip ping step').default(
   true,
 );
@@ -225,4 +230,5 @@ export {
   passwordMemLimit,
   depth,
   commitId,
+  overrideClone,
 };

--- a/src/vaults/CommandClone.ts
+++ b/src/vaults/CommandClone.ts
@@ -20,6 +20,7 @@ class CommandClone extends CommandPolykey {
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
+    this.addOption(binOptions.overrideClone);
     this.action(async (vaultNameOrId, nodeId: NodeId, options) => {
       const { default: PolykeyClient } = await import(
         'polykey/dist/PolykeyClient'
@@ -57,6 +58,7 @@ class CommandClone extends CommandPolykey {
             pkClient.rpcClient.methods.vaultsClone({
               metadata: auth,
               nodeIdEncoded: nodesUtils.encodeNodeId(nodeId),
+              force: options.override,
               nameOrId: vaultNameOrId,
             }),
           meta,


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->

In CLI, an option has been added to override the default cloning behaviour. 

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #73 

### Tasks

- [x] 1. Add override for cloning
- [x] 2. Pass the override in CloneVault

### Final checklist
* [x] Domain specific tests
* [x] Full tests
* [ ] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [ ] Sanity check the final build
