### PR TITLE
Fix overlay compatibility

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,7 +69,7 @@ check:nix-dry:
     - >
       nix-shell --arg ci true --run $'
       npmDepsHash="$(prefetch-npm-deps ./package-lock.json)";
-      nix-build -v -v --dry-run ./release.nix --argstr npmDepsHash "$npmDepsHash";
+      nix-build -v -v --dry-run ./release.nix --argstr npmDepsHash "$npmDepsHash" --argstr commitHash "$CI_COMMIT_SHA";
       '
   rules:
     # Runs on feature and staging commits and ignores version commits

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,6 @@
 { npmDepsHash ? ""
 , commitHash ? null
+, gitDir ? null
 , callPackage
 , buildNpmPackage
 }:
@@ -18,7 +19,7 @@ in
       version = utils.packageVersion;
       src = utils.src;
       COMMIT_HASH = commitHash;
-      GIT_DIR = utils.dotGit;
+      GIT_DIR = gitDir;
       # Filter out things kept by `src`, these were needed for building
       # but not needed for subsequent usage of the store path
       postInstall = ''

--- a/release.nix
+++ b/release.nix
@@ -1,5 +1,6 @@
 { npmDepsHash ? ""
 , commitHash ? null
+, gitDir ? null
 , pkgs ? import ./pkgs.nix {}
 }:
 
@@ -18,7 +19,7 @@ let
         src = utils.src;
         PKG_CACHE_PATH = utils.pkgCachePath;
         PKG_IGNORE_TAG = 1;
-        GIT_DIR = utils.dotGit;
+        GIT_DIR = gitDir;
         postBuild = ''
           npm run pkg -- \
             --output=out \

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -17,7 +17,7 @@ async function main(argv = process.argv) {
   const projectRoot = path.join(__dirname, '..');
   const buildPath = path.join(projectRoot, 'build');
   const distPath = path.join(projectRoot, 'dist');
-  const gitPath = process.env.GIT_DIR ?? path.join(projectRoot, '.git');
+
   await fs.promises.rm(distPath, {
     recursive: true,
     force: true,
@@ -31,9 +31,11 @@ async function main(argv = process.argv) {
     encoding: 'utf-8',
     shell: platform === 'win32' ? true : false,
   });
+
   // This collects the build metadata and adds it to the build folder so that dynamic imports to it will resolve correctly.
   let gitHead = process.env.COMMIT_HASH;
   if (gitHead == null) {
+    const gitPath = process.env.GIT_DIR ?? path.join(projectRoot, '.git');
     gitHead = await fs.promises.readFile(path.join(gitPath, 'HEAD'), 'utf-8');
     if (gitHead.startsWith('ref: ')) {
       const refPath = gitHead.slice(5).trim();

--- a/utils.nix
+++ b/utils.nix
@@ -25,7 +25,6 @@ rec {
     "/tests"
     "/jest.config.js"
   ] ./.;
-  dotGit = ./.git;
   packageJSON = builtins.fromJSON (builtins.readFile "${src}/package.json");
   # This removes the org scoping
   packageName = builtins.baseNameOf packageJSON.name;


### PR DESCRIPTION
### Description
This pull request fixes a problem to do with how the commitHash is calculated. Within the default.nix, GIT_DIR is evaluated at compile time with the path './.git', however in a build environment like in a nixpkgs overlay, this isn't taken into account and the path cannot be evaluated to the correct .git directory. This will always happen regardless of if commitHash was set or not. Therefore, the only way to fix this is to actually remove the GIT_DIR line from default.nix, and instead rely purely on hard coded file paths within build.js. This successfuly allows Polykey-CLI to be integrated with a nixpkgs overlay, and can now be deployed as such.

### Tasks
- [x] 1. Remove dependency on GIT_DIR variable
- [x] 2. Deploy to downstream overlay
- [x] 3. Test to see if Polykey-CLI is able to be built through an overlay on Nix
- [x] 4. Update CI to use the commit hash parameter

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
