### PR TITLE
Creating `secrets env` command

### DIFF
--- a/npmDepsHash
+++ b/npmDepsHash
@@ -1,1 +1,1 @@
-sha256-Tkycu9+7Kwjvuaplw38b/t1N4ZRdsOack5OC0ZO0cxo=
+sha256-hS9LURKsHIb8bg/LEbGGkrHP4oAxDGeQKvopl8PhuL4=

--- a/npmDepsHash
+++ b/npmDepsHash
@@ -1,1 +1,1 @@
-sha256-buIzGNjR5CMM7BNlw5srJtVTSH/6Ru+UsMeXeNOjgZ4=
+sha256-LZ3QekhwOZj3IkbnZVdC/lbUvwhbJXROzd9oTxrMs7s=

--- a/npmDepsHash
+++ b/npmDepsHash
@@ -1,1 +1,1 @@
-sha256-LZ3QekhwOZj3IkbnZVdC/lbUvwhbJXROzd9oTxrMs7s=
+sha256-Tkycu9+7Kwjvuaplw38b/t1N4ZRdsOack5OC0ZO0cxo=

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "nexpect": "^0.6.0",
         "node-gyp-build": "^4.4.0",
         "nodemon": "^3.0.1",
-        "polykey": "^1.2.1-alpha.47",
+        "polykey": "^1.2.1-alpha.49",
         "prettier": "^3.0.0",
         "shelljs": "^0.8.5",
         "shx": "^0.3.4",
@@ -1476,9 +1476,9 @@
       ]
     },
     "node_modules/@matrixai/quic": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic/-/quic-1.1.4.tgz",
-      "integrity": "sha512-WhwoFzw2fuxDCxzY/WTZnMHg2snSGpGvifh4K6iRPfnvUfKME0ikFty7EMkRt8bQiAes4yxBbcI72/wBSeTYMA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic/-/quic-1.2.1.tgz",
+      "integrity": "sha512-Dz/IzRrYIV407aG3GAM7+4eoqntBZ/QOP4sBugd/5ZgiS8vwIdXQzzfGfetcM9SRp3I67v5teXDpavb4JAcWYg==",
       "dev": true,
       "dependencies": {
         "@matrixai/async-cancellable": "^1.1.1",
@@ -1493,16 +1493,16 @@
         "ip-num": "^1.5.0"
       },
       "optionalDependencies": {
-        "@matrixai/quic-darwin-arm64": "1.1.4",
-        "@matrixai/quic-darwin-x64": "1.1.4",
-        "@matrixai/quic-linux-x64": "1.1.4",
-        "@matrixai/quic-win32-x64": "1.1.4"
+        "@matrixai/quic-darwin-arm64": "1.2.1",
+        "@matrixai/quic-darwin-x64": "1.2.1",
+        "@matrixai/quic-linux-x64": "1.2.1",
+        "@matrixai/quic-win32-x64": "1.2.1"
       }
     },
     "node_modules/@matrixai/quic-darwin-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-arm64/-/quic-darwin-arm64-1.1.4.tgz",
-      "integrity": "sha512-/Dho39T4sjbdOeC01F4rDesssQ9nvfdH57Ap95870LoY1KwXWh+c7cAtdv9FVma2R+9cqdKNkfsMFcS68Y15KA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-arm64/-/quic-darwin-arm64-1.2.1.tgz",
+      "integrity": "sha512-TutHRdQoPYPvwg8Fs6t+JmedKWn/7mJG63c5ZFyw9D58a90OzYr47re2qknKNjH/dgBIyybhBYTAltkOcXxzOg==",
       "cpu": [
         "arm64"
       ],
@@ -1512,9 +1512,9 @@
       ]
     },
     "node_modules/@matrixai/quic-darwin-x64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-x64/-/quic-darwin-x64-1.1.4.tgz",
-      "integrity": "sha512-soxYopXZjoHxSMvpoNEKQQS1uQcXK2aIuaJHDgZINz4UbeLW0NsoEqMgUJKXeWZNR+aaVxhL5fE5+5Ypwej80Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-x64/-/quic-darwin-x64-1.2.1.tgz",
+      "integrity": "sha512-HMIhCHjAvvAgSap2gQyKYgWyhikDtmU9KbqtReMT3tP8KG3jNPAw2YuF7vucVR9k6FaMufISLYyBvWQSadTxIg==",
       "cpu": [
         "x64"
       ],
@@ -1524,9 +1524,9 @@
       ]
     },
     "node_modules/@matrixai/quic-linux-x64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-linux-x64/-/quic-linux-x64-1.1.4.tgz",
-      "integrity": "sha512-LRKkVX++UZEj00XhfD0cPe4uFQJeHOBpQl+v6BIL7LSB9KxsmQRgbDh5mvxvWAwnh5EI51aSgn4auWEdHMDjTw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-linux-x64/-/quic-linux-x64-1.2.1.tgz",
+      "integrity": "sha512-WgvzATQhuVMV1cCiV0rRS9Tn3BL6LZ37OWBeQY20OJB4yaF9FR3xgUdATY3AVgF1FAdwvCHUJCF5BgzQmq8NMw==",
       "cpu": [
         "x64"
       ],
@@ -1536,9 +1536,9 @@
       ]
     },
     "node_modules/@matrixai/quic-win32-x64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-win32-x64/-/quic-win32-x64-1.1.4.tgz",
-      "integrity": "sha512-JNIQn1GRCRDm23v7hkqNVRm0oV928AHVfNPXJOB6FqBtbmbe/DaqUnppFi3qqUxm5Agguhd1rgNfKkL4HRhq8A==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-win32-x64/-/quic-win32-x64-1.2.1.tgz",
+      "integrity": "sha512-2F/llbBRzd2ohLLBZSW2ZIQTq8EHZ6jsrkv+/x0gggvRKaoPKmE2UMqcAYrfX/h5D48Gb3/JynD6AtFYGSBKFw==",
       "cpu": [
         "x64"
       ],
@@ -7488,9 +7488,9 @@
       }
     },
     "node_modules/polykey": {
-      "version": "1.2.1-alpha.47",
-      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.2.1-alpha.47.tgz",
-      "integrity": "sha512-nFQkDY8oE3ZcQgRlKrDIYFhYXzxJbFh3UAAxIovPG9HwO33jXbHckmsqLdir9p9wKgjvA57/RR7WTD5BaNh7Tg==",
+      "version": "1.2.1-alpha.49",
+      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.2.1-alpha.49.tgz",
+      "integrity": "sha512-81kWTeJ6M8x6I/cbuHMEBFLo7K6cbT7NNNVPfNsnp8JJaeGQmwTAODCS4WGP7wqAC0NVTFRaqYMUpNVvbJ9RNQ==",
       "dev": true,
       "dependencies": {
         "@matrixai/async-cancellable": "^1.1.1",
@@ -7503,7 +7503,7 @@
         "@matrixai/id": "^3.3.6",
         "@matrixai/logger": "^3.1.2",
         "@matrixai/mdns": "^1.2.5",
-        "@matrixai/quic": "^1.1.4",
+        "@matrixai/quic": "^1.2.1",
         "@matrixai/resources": "^1.1.5",
         "@matrixai/rpc": "^0.5.0",
         "@matrixai/timer": "^1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@matrixai/errors": "^1.2.0",
-        "@matrixai/exec": "^0.1.1",
+        "@matrixai/exec": "^0.1.2",
         "@matrixai/logger": "^3.1.0",
         "@swc/core": "1.3.82",
         "@swc/jest": "^0.2.29",
@@ -1423,20 +1423,20 @@
       "devOptional": true
     },
     "node_modules/@matrixai/exec": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@matrixai/exec/-/exec-0.1.1.tgz",
-      "integrity": "sha512-jKq8cVRFMPOuKyNfTjLrg+LoIZPLkDrRs0uQyx5fv8v1Uc1eiBOnQsvOh33VyVCsFMiK+aSukLoE/7xh8Yq5GQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@matrixai/exec/-/exec-0.1.2.tgz",
+      "integrity": "sha512-5hvfIDrNqMjTRdpPNxZ5wdJe9uzJSRzRAy8nycc7s1kFhmvYteIiiE0oRRGIRzaKWkQQicGypr+W3jJd/1r3kQ==",
       "dev": true,
       "optionalDependencies": {
-        "@matrixai/exec-darwin-arm64": "0.1.1",
-        "@matrixai/exec-darwin-x64": "0.1.1",
-        "@matrixai/exec-linux-x64": "0.1.1"
+        "@matrixai/exec-darwin-arm64": "0.1.2",
+        "@matrixai/exec-darwin-x64": "0.1.2",
+        "@matrixai/exec-linux-x64": "0.1.2"
       }
     },
     "node_modules/@matrixai/exec-darwin-arm64": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@matrixai/exec-darwin-arm64/-/exec-darwin-arm64-0.1.1.tgz",
-      "integrity": "sha512-JabHQa+/uA8Viqab7br40kOWVVIhotoyQnVQppzUt8ed/7npWczQQKtdspAafG3AjUSCxcg6aptaUX3NZ8/A4g==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@matrixai/exec-darwin-arm64/-/exec-darwin-arm64-0.1.2.tgz",
+      "integrity": "sha512-sl2uD8Dbv3pAOVyUJsnDkNflh+xd4h8k/svQX4DycepcTIGKClBRc7Y09krgwcVPqjQH/daWVhDsKFDyNx0JGw==",
       "cpu": [
         "arm64"
       ],
@@ -1447,9 +1447,9 @@
       ]
     },
     "node_modules/@matrixai/exec-darwin-x64": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@matrixai/exec-darwin-x64/-/exec-darwin-x64-0.1.1.tgz",
-      "integrity": "sha512-i7ShSWrM8bbB9GUtMbhTlyRjzAB/hw1eDYHEFFNFJvMJ220p902TbJTajb9+OxHD/6vk3arslo1uA9okr5ZHvA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@matrixai/exec-darwin-x64/-/exec-darwin-x64-0.1.2.tgz",
+      "integrity": "sha512-qGV9ePdnjMloVSgAhCSWR3aBnyG9Af+o6Ma+LRgpv4VGlykxz+z+3zGxrJbEB1zJXF4ID7TD94TlBiRPC9zKmg==",
       "cpu": [
         "x64"
       ],
@@ -1460,9 +1460,9 @@
       ]
     },
     "node_modules/@matrixai/exec-linux-x64": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@matrixai/exec-linux-x64/-/exec-linux-x64-0.1.1.tgz",
-      "integrity": "sha512-AlGoFHGDSDsFjUXjTnVXRGMLYfb/Y1ApblSQ4xWhZo/xwqi0of9+85LxDicboEPl5k6teRbYV9BY4DRmZYbFfA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@matrixai/exec-linux-x64/-/exec-linux-x64-0.1.2.tgz",
+      "integrity": "sha512-EG0/EZOVvaDLqHLNoBp7mrA1ugbXs2N9EbGM6WyjP3xp8T7ILVHB1gGyiNUEXwN6hQ8wvEnqaLQ8+NRltXAoyg==",
       "cpu": [
         "x64"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@matrixai/errors": "^1.2.0",
+        "@matrixai/exec": "^0.1.1",
         "@matrixai/logger": "^3.1.0",
         "@swc/core": "1.3.82",
         "@swc/jest": "^0.2.29",
@@ -1420,6 +1421,56 @@
       "resolved": "https://registry.npmjs.org/@matrixai/events/-/events-3.2.3.tgz",
       "integrity": "sha512-bZrNCwzYeFalGQpn8qa/jgD10mUAwLRbv6xGMI7gGz1f+vE65d3GPoJ6JoFOJSg9iCmRSayQJ+IipH3LMATvDA==",
       "devOptional": true
+    },
+    "node_modules/@matrixai/exec": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/exec/-/exec-0.1.1.tgz",
+      "integrity": "sha512-jKq8cVRFMPOuKyNfTjLrg+LoIZPLkDrRs0uQyx5fv8v1Uc1eiBOnQsvOh33VyVCsFMiK+aSukLoE/7xh8Yq5GQ==",
+      "dev": true,
+      "optionalDependencies": {
+        "@matrixai/exec-darwin-arm64": "0.1.1",
+        "@matrixai/exec-darwin-x64": "0.1.1",
+        "@matrixai/exec-linux-x64": "0.1.1"
+      }
+    },
+    "node_modules/@matrixai/exec-darwin-arm64": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/exec-darwin-arm64/-/exec-darwin-arm64-0.1.1.tgz",
+      "integrity": "sha512-JabHQa+/uA8Viqab7br40kOWVVIhotoyQnVQppzUt8ed/7npWczQQKtdspAafG3AjUSCxcg6aptaUX3NZ8/A4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@matrixai/exec-darwin-x64": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/exec-darwin-x64/-/exec-darwin-x64-0.1.1.tgz",
+      "integrity": "sha512-i7ShSWrM8bbB9GUtMbhTlyRjzAB/hw1eDYHEFFNFJvMJ220p902TbJTajb9+OxHD/6vk3arslo1uA9okr5ZHvA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@matrixai/exec-linux-x64": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/exec-linux-x64/-/exec-linux-x64-0.1.1.tgz",
+      "integrity": "sha512-AlGoFHGDSDsFjUXjTnVXRGMLYfb/Y1ApblSQ4xWhZo/xwqi0of9+85LxDicboEPl5k6teRbYV9BY4DRmZYbFfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@matrixai/id": {
       "version": "3.3.6",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "nexpect": "^0.6.0",
     "node-gyp-build": "^4.4.0",
     "nodemon": "^3.0.1",
-    "polykey": "^1.2.1-alpha.47",
+    "polykey": "^1.2.1-alpha.49",
     "prettier": "^3.0.0",
     "shelljs": "^0.8.5",
     "shx": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
   "devDependencies": {
     "@matrixai/errors": "^1.2.0",
     "@matrixai/logger": "^3.1.0",
-    "@matrixai/exec": "^0.1.1",
+    "@matrixai/exec": "^0.1.2",
     "@swc/core": "1.3.82",
     "@swc/jest": "^0.2.29",
     "@types/jest": "^29.5.2",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
   "devDependencies": {
     "@matrixai/errors": "^1.2.0",
     "@matrixai/logger": "^3.1.0",
+    "@matrixai/exec": "^0.1.1",
     "@swc/core": "1.3.82",
     "@swc/jest": "^0.2.29",
     "@types/jest": "^29.5.2",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -141,6 +141,17 @@ class ErrorPolykeyCLINodePingFailed<T> extends ErrorPolykeyCLI<T> {
   exitCode = 1;
 }
 
+class ErrorPolykeyCLIInvalidEnvName<T> extends ErrorPolykeyCLI<T> {
+  static description =
+    'Secret retrieved has an invalid environment variable name';
+  exitCode = sysexits.USAGE;
+}
+
+class ErrorPolykeyCLIDuplicateEnvName<T> extends ErrorPolykeyCLI<T> {
+  static description = 'Environment variable name already retrieved';
+  exitCode = sysexits.USAGE;
+}
+
 export {
   ErrorPolykeyCLI,
   ErrorPolykeyCLIUncaughtException,
@@ -159,4 +170,6 @@ export {
   ErrorPolykeyCLIAgentProcess,
   ErrorPolykeyCLINodeFindFailed,
   ErrorPolykeyCLINodePingFailed,
+  ErrorPolykeyCLIInvalidEnvName,
+  ErrorPolykeyCLIDuplicateEnvName,
 };

--- a/src/secrets/CommandEnv.ts
+++ b/src/secrets/CommandEnv.ts
@@ -13,7 +13,7 @@ class CommandEnv extends CommandPolykey {
     super(...args);
     this.name('env');
     this.description(
-      'Run a command with the given secrets and env variables. If no command is specified then the variables are printed to stdout.',
+      `Run a command with the given secrets and env variables. If no command is specified then the variables are printed to stdout in the format specified by env-format.\n\nWhen selecting secrets with --env secrets with invalid names can be selected. By default when these are encountered then the command will throw an error. This behaviour can be modified with '--env-invalid'. the invalid name can be silently dropped with 'ignore' or logged out with 'warn'\n\nDuplicate secret names can be specified, by default with 'overwrite' the env variable will be overwritten with the latest found secret of that name. It can be specified to 'keep' the first found secret of that name, 'error' to throw if there is a duplicate and 'warn' to log a warning while overwriting.`,
     );
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);

--- a/src/secrets/CommandEnv.ts
+++ b/src/secrets/CommandEnv.ts
@@ -11,6 +11,15 @@ import * as binOptions from '../utils/options';
 class CommandEnv extends CommandPolykey {
   constructor(...args: ConstructorParameters<typeof CommandPolykey>) {
     super(...args);
+
+    // Modify the --format choices to include `dotenv` and `prepend`
+    // @ts-ignore: missing type for `options`
+    const formatOption = this.options.filter((v) => v.short === '-f')[0];
+    if (formatOption == null) {
+      utils.never('The -f --format option should exist');
+    }
+    formatOption.argChoices.push('dotenv', 'prepend');
+
     this.name('env');
     this.description(
       `Run a command with the given secrets and env variables. If no command is specified then the variables are printed to stdout in the format specified by env-format.\n\nWhen selecting secrets with --env secrets with invalid names can be selected. By default when these are encountered then the command will throw an error. This behaviour can be modified with '--env-invalid'. the invalid name can be silently dropped with 'ignore' or logged out with 'warn'\n\nDuplicate secret names can be specified, by default with 'overwrite' the env variable will be overwritten with the latest found secret of that name. It can be specified to 'keep' the first found secret of that name, 'error' to throw if there is a duplicate and 'warn' to log a warning while overwriting.`,
@@ -19,7 +28,6 @@ class CommandEnv extends CommandPolykey {
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
     this.addOption(binOptions.envVariables);
-    this.addOption(binOptions.envFormat);
     this.addOption(binOptions.envInvalid);
     this.addOption(binOptions.envDuplicate);
     this.argument('[cmd] [argv...]', 'command and arguments');
@@ -29,12 +37,12 @@ class CommandEnv extends CommandPolykey {
         env: envVariables,
         envInvalid,
         envDuplicate,
-        envFormat,
+        format,
       }: {
         env: Array<[string, string, string?]>;
         envInvalid: 'error' | 'warn' | 'ignore';
         envDuplicate: 'keep' | 'overwrite' | 'warn' | 'error';
-        envFormat: 'dotenv' | 'json' | 'prepend';
+        format: 'human' | 'dotenv' | 'json' | 'prepend';
       } = options;
 
       // There are a few stages here
@@ -183,7 +191,9 @@ class CommandEnv extends CommandPolykey {
           }
         } else {
           // Otherwise we switch between output formats
-          switch (envFormat) {
+          switch (format) {
+            case 'human':
+            // Fallthrough
             case 'dotenv':
               {
                 // Formatting as a .env file

--- a/src/secrets/CommandSecrets.ts
+++ b/src/secrets/CommandSecrets.ts
@@ -2,7 +2,7 @@ import CommandCreate from './CommandCreate';
 import CommandDelete from './CommandDelete';
 import CommandDir from './CommandDir';
 import CommandEdit from './CommandEdit';
-// Import CommandEnv from './CommandEnv';
+import CommandEnv from './CommandEnv';
 import CommandGet from './CommandGet';
 import CommandList from './CommandList';
 import CommandMkdir from './CommandMkdir';
@@ -20,7 +20,7 @@ class CommandSecrets extends CommandPolykey {
     this.addCommand(new CommandDelete(...args));
     this.addCommand(new CommandDir(...args));
     this.addCommand(new CommandEdit(...args));
-    // This.addCommand(new CommandEnv(...args));
+    this.addCommand(new CommandEnv(...args));
     this.addCommand(new CommandGet(...args));
     this.addCommand(new CommandList(...args));
     this.addCommand(new CommandMkdir(...args));

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -202,18 +202,32 @@ const envVariables = new commander.Option('-e --env <envs...>', 'specify envs')
   .argParser(
     (value: string, previous: Array<[string, string, string?]> | undefined) => {
       const acc = previous ?? [];
-      acc.push(binParsers.parseSecretPath(value));
+      acc.push(binParsers.parseEnvPath(value));
       return acc;
     },
   );
 
 // '-f, --format <format>', 'Output Format'
 const envFormat = new commander.Option(
-  '-of --output-format <outputFormat>',
+  '-ef --env-format <outputFormat>',
   'How the env variables are formatted when outputted. Only used if no commands are executed',
 )
   .choices(['dotenv', 'json', 'prepend'])
   .default('dotenv');
+
+const envInvalid = new commander.Option(
+  '-ei --env-invalid <envInvalid>',
+  'How invalid env variable names are handled when retrieving secrets. `error` will throw, `warn` will log a warning and drop and `ignore` will silently drop.',
+)
+  .choices(['error', 'warn', 'ignore'])
+  .default('error');
+
+const envDuplicate = new commander.Option(
+  '-ed --env-duplicate <envDuplicate>',
+  'How duplicate env variable names are handled. `keep` will keep the exising secret, `overwrite` will overwrite existing with the new secret, `warn` will log a warning and overwrite and `error` will throw.',
+)
+  .choices(['keep', 'overwrite', 'warn', 'error'])
+  .default('overwrite');
 
 export {
   nodePath,
@@ -245,4 +259,6 @@ export {
   commitId,
   envVariables,
   envFormat,
+  envInvalid,
+  envDuplicate,
 };

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -207,14 +207,6 @@ const envVariables = new commander.Option('-e --env <envs...>', 'specify envs')
     },
   );
 
-// '-f, --format <format>', 'Output Format'
-const envFormat = new commander.Option(
-  '-ef --env-format <outputFormat>',
-  'How the env variables are formatted when outputted. Only used if no commands are executed',
-)
-  .choices(['dotenv', 'json', 'prepend'])
-  .default('dotenv');
-
 const envInvalid = new commander.Option(
   '-ei --env-invalid <envInvalid>',
   'How invalid env variable names are handled when retrieving secrets. `error` will throw, `warn` will log a warning and drop and `ignore` will silently drop.',
@@ -258,7 +250,6 @@ export {
   depth,
   commitId,
   envVariables,
-  envFormat,
   envInvalid,
   envDuplicate,
 };

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -197,6 +197,24 @@ const commitId = new commander.Option(
   'Id for a specific commit to read from',
 );
 
+const envVariables = new commander.Option('-e --env <envs...>', 'specify envs')
+  .makeOptionMandatory(true)
+  .argParser(
+    (value: string, previous: Array<[string, string, string?]> | undefined) => {
+      const acc = previous ?? [];
+      acc.push(binParsers.parseSecretPath(value));
+      return acc;
+    },
+  );
+
+// '-f, --format <format>', 'Output Format'
+const envFormat = new commander.Option(
+  '-of --output-format <outputFormat>',
+  'How the env variables are formatted when outputted. Only used if no commands are executed',
+)
+  .choices(['dotenv', 'json', 'prepend'])
+  .default('dotenv');
+
 export {
   nodePath,
   format,
@@ -225,4 +243,6 @@ export {
   passwordMemLimit,
   depth,
   commitId,
+  envVariables,
+  envFormat,
 };

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -76,6 +76,23 @@ function parseSecretPath(secretPath: string): [string, string, string?] {
   return [vaultName, directoryPath, value];
 }
 
+function parseEnvPath(secretPath: string): [string, string, string?] {
+  // E.g. If 'vault1:a/b/c', ['vault1', 'a/b/c'] is returned
+  //      If 'vault1:a/b/c=VARIABLE', ['vault1, 'a/b/c', 'VARIABLE'] is returned
+  // VARIABLE must be a valid ENV variable name
+  const secretPathRegex =
+    /^([\w-]+)(?::)([\w\-\\\/\.\$]+)(?:=)?([a-zA-Z_]+[a-zA-Z0-9_]*)?$/;
+  // /^([\w-]+)(?::)([\w\-\\\/\.\$]+)(?:=)?([a-zA-Z_][\w]+)?$/;
+  if (!secretPathRegex.test(secretPath)) {
+    throw new commander.InvalidArgumentError(
+      `${secretPath} is not of the format <vaultName>:<directoryPath>`,
+    );
+  }
+  const [, vaultName, directoryPath, value] =
+    secretPath.match(secretPathRegex)!;
+  return [vaultName, directoryPath, value];
+}
+
 const parseInteger: (data: string) => number = validateParserToArgParser(
   validationUtils.parseInteger,
 );
@@ -132,6 +149,7 @@ export {
   validateParserToArgListParser,
   parseCoreCount,
   parseSecretPath,
+  parseEnvPath,
   parseInteger,
   parseNumber,
   parseNodeId,

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -71,8 +71,9 @@ function parseSecretPath(secretPath: string): [string, string, string?] {
       `${secretPath} is not of the format <vaultName>:<directoryPath>`,
     );
   }
-  const [, vaultName, directoryPath] = secretPath.match(secretPathRegex)!;
-  return [vaultName, directoryPath, undefined];
+  const [, vaultName, directoryPath, value] =
+    secretPath.match(secretPathRegex)!;
+  return [vaultName, directoryPath, value];
 }
 
 const parseInteger: (data: string) => number = validateParserToArgParser(

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -509,6 +509,8 @@ function remoteErrorCause(e: any): [any, number] {
   return [errorCause, depth];
 }
 
+const validEnvRegex = /[a-zA-Z_]+[a-zA-Z0-9_]*/;
+
 export {
   verboseToLogLevel,
   standardErrorReplacer,
@@ -527,6 +529,7 @@ export {
   decodeEscapedWrapped,
   decodeEscaped,
   decodeEscapedRegex,
+  validEnvRegex,
 };
 
 export type { OutputObject };

--- a/tests/secrets/env.test.ts
+++ b/tests/secrets/env.test.ts
@@ -1,0 +1,382 @@
+import type { VaultName } from 'polykey/dist/vaults/types';
+import path from 'path';
+import fs from 'fs';
+import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
+import PolykeyAgent from 'polykey/dist/PolykeyAgent';
+import { vaultOps } from 'polykey/dist/vaults';
+import * as keysUtils from 'polykey/dist/keys/utils';
+import * as testUtils from '../utils';
+
+describe('commandEnv', () => {
+  const logger = new Logger('CLI Test', LogLevel.WARN, [new StreamHandler()]);
+  const password = 'password';
+  const vaultName = 'vault' as VaultName;
+  let dataDir: string;
+  let polykeyAgent: PolykeyAgent;
+  let passwordFile: string;
+  let command: Array<string>;
+
+  beforeEach(async () => {
+    dataDir = await fs.promises.mkdtemp(
+      path.join(globalThis.tmpDir, 'polykey-test-'),
+    );
+    passwordFile = path.join(dataDir, 'passwordFile');
+    await fs.promises.writeFile(passwordFile, 'password');
+    polykeyAgent = await PolykeyAgent.createPolykeyAgent({
+      password,
+      options: {
+        nodePath: dataDir,
+        agentServiceHost: '127.0.0.1',
+        clientServiceHost: '127.0.0.1',
+        keys: {
+          passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+          passwordMemLimit: keysUtils.passwordMemLimits.min,
+          strictMemoryLock: false,
+        },
+      },
+      logger: logger,
+    });
+    // Authorize session
+    await testUtils.pkStdio(
+      ['agent', 'unlock', '-np', dataDir, '--password-file', passwordFile],
+      {
+        env: {},
+        cwd: dataDir,
+      },
+    );
+  });
+  afterEach(async () => {
+    await polykeyAgent.stop();
+    await fs.promises.rm(dataDir, {
+      force: true,
+      recursive: true,
+    });
+  });
+
+  test('can select 1 env variable', async () => {
+    const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
+
+    await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
+      await vaultOps.addSecret(vault, 'SECRET', 'this is the secret1');
+    });
+
+    command = [
+      'secrets',
+      'env',
+      '-np',
+      dataDir,
+      '-e',
+      `${vaultName}:SECRET`,
+      '--',
+      'node',
+      '-e',
+      'console.log(JSON.stringify(process.env))',
+    ];
+
+    const result = await testUtils.pkExec([...command]);
+    expect(result.exitCode).toBe(0);
+    const jsonOut = JSON.parse(result.stdout);
+    expect(jsonOut['SECRET']).toBe('this is the secret1');
+  });
+  test('can select multiple env variables', async () => {
+    const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
+
+    await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
+      await vaultOps.addSecret(vault, 'SECRET1', 'this is the secret1');
+      await vaultOps.addSecret(vault, 'SECRET2', 'this is the secret2');
+    });
+
+    command = [
+      'secrets',
+      'env',
+      '-np',
+      dataDir,
+      '-e',
+      `${vaultName}:SECRET1`,
+      `${vaultName}:SECRET2`,
+      '--',
+      'node',
+      '-e',
+      'console.log(JSON.stringify(process.env))',
+    ];
+
+    const result = await testUtils.pkExec([...command]);
+    expect(result.exitCode).toBe(0);
+    const jsonOut = JSON.parse(result.stdout);
+    expect(jsonOut['SECRET1']).toBe('this is the secret1');
+    expect(jsonOut['SECRET2']).toBe('this is the secret2');
+  });
+  test('can select a directory of env variables', async () => {
+    const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
+
+    await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
+      await vaultOps.addSecret(vault, 'SECRET1', 'this is the secret1');
+      await vaultOps.mkdir(vault, 'dir1');
+      await vaultOps.addSecret(vault, 'dir1/SECRET2', 'this is the secret2');
+      await vaultOps.addSecret(vault, 'dir1/SECRET3', 'this is the secret3');
+    });
+
+    command = [
+      'secrets',
+      'env',
+      '-np',
+      dataDir,
+      '-e',
+      `${vaultName}:dir1`,
+      '--',
+      'node',
+      '-e',
+      'console.log(JSON.stringify(process.env))',
+    ];
+
+    const result = await testUtils.pkExec([...command]);
+    expect(result.exitCode).toBe(0);
+    const jsonOut = JSON.parse(result.stdout);
+    expect(jsonOut['SECRET1']).toBeUndefined();
+    expect(jsonOut['SECRET2']).toBe('this is the secret2');
+    expect(jsonOut['SECRET3']).toBe('this is the secret3');
+  });
+  test('can select and rename an env variable', async () => {
+    const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
+
+    await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
+      await vaultOps.addSecret(vault, 'SECRET', 'this is the secret');
+    });
+
+    command = [
+      'secrets',
+      'env',
+      '-np',
+      dataDir,
+      '-e',
+      `${vaultName}:SECRET=SECRET_NEW`,
+      '--',
+      'node',
+      '-e',
+      'console.log(JSON.stringify(process.env))',
+    ];
+
+    const result = await testUtils.pkExec([...command]);
+    expect(result.exitCode).toBe(0);
+    const jsonOut = JSON.parse(result.stdout);
+    expect(jsonOut['SECRET']).toBeUndefined();
+    expect(jsonOut['SECRET_NEW']).toBe('this is the secret');
+  });
+  test('can not rename a directory of env variables', async () => {
+    const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
+
+    await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
+      await vaultOps.mkdir(vault, 'dir');
+      await vaultOps.addSecret(vault, 'dir1/SECRET1', 'this is the secret1');
+      await vaultOps.addSecret(vault, 'dir1/SECRET2', 'this is the secret2');
+    });
+
+    command = [
+      'secrets',
+      'env',
+      '-np',
+      dataDir,
+      '-e',
+      `${vaultName}:dir1=SECRET_NEW`,
+      '--',
+      'node',
+      '-e',
+      'console.log(JSON.stringify(process.env))',
+    ];
+
+    const result = await testUtils.pkExec([...command]);
+    expect(result.exitCode).toBe(0);
+    const jsonOut = JSON.parse(result.stdout);
+    expect(jsonOut['SECRET_NEW']).toBeUndefined();
+    expect(jsonOut['SECRET1']).toBe('this is the secret1');
+    expect(jsonOut['SECRET2']).toBe('this is the secret2');
+  });
+  test('can mix and match env variables', async () => {
+    const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
+
+    await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
+      await vaultOps.addSecret(vault, 'SECRET1', 'this is the secret1');
+      await vaultOps.addSecret(vault, 'SECRET2', 'this is the secret2');
+      await vaultOps.mkdir(vault, 'dir1');
+      await vaultOps.addSecret(vault, 'dir1/SECRET3', 'this is the secret3');
+      await vaultOps.addSecret(vault, 'dir1/SECRET4', 'this is the secret4');
+    });
+
+    command = [
+      'secrets',
+      'env',
+      '-np',
+      dataDir,
+      '-e',
+      `${vaultName}:SECRET1`,
+      `${vaultName}:SECRET2`,
+      `${vaultName}:dir1`,
+      '--',
+      'node',
+      '-e',
+      'console.log(JSON.stringify(process.env))',
+    ];
+
+    const result = await testUtils.pkExec([...command]);
+    expect(result.exitCode).toBe(0);
+    const jsonOut = JSON.parse(result.stdout);
+    expect(jsonOut['SECRET1']).toBe('this is the secret1');
+    expect(jsonOut['SECRET2']).toBe('this is the secret2');
+    expect(jsonOut['SECRET3']).toBe('this is the secret3');
+    expect(jsonOut['SECRET4']).toBe('this is the secret4');
+  });
+  test('existing env are passed through', async () => {
+    const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
+
+    await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
+      await vaultOps.addSecret(vault, 'SECRET1', 'this is the secret1');
+    });
+
+    command = [
+      'secrets',
+      'env',
+      '-np',
+      dataDir,
+      '-e',
+      `${vaultName}:SECRET1`,
+      '--',
+      'node',
+      '-e',
+      'console.log(JSON.stringify(process.env))',
+    ];
+
+    const result = await testUtils.pkExec([...command], {
+      env: {
+        EXISTING: 'existing var',
+      },
+    });
+    expect(result.exitCode).toBe(0);
+    const jsonOut = JSON.parse(result.stdout);
+    expect(jsonOut['SECRET1']).toBe('this is the secret1');
+    expect(jsonOut['EXISTING']).toBe('existing var');
+  });
+  test('handles duplicate secret names', async () => {
+    const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
+
+    await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
+      await vaultOps.addSecret(vault, 'SECRET1', 'this is the secret1');
+      await vaultOps.addSecret(vault, 'SECRET2', 'this is the secret2');
+      await vaultOps.addSecret(vault, 'SECRET3', 'this is the secret3');
+      await vaultOps.mkdir(vault, 'dir1');
+      await vaultOps.addSecret(vault, 'dir1/SECRET4', 'this is the secret4');
+    });
+
+    command = [
+      'secrets',
+      'env',
+      '-np',
+      dataDir,
+      '-e',
+      `${vaultName}:SECRET1`,
+      `${vaultName}:SECRET2=SECRET1`,
+      `${vaultName}:SECRET3=SECRET4`,
+      `${vaultName}:dir1`,
+      '--',
+      'node',
+      '-e',
+      'console.log(JSON.stringify(process.env))',
+    ];
+
+    const result = await testUtils.pkExec([...command]);
+    expect(result.exitCode).toBe(0);
+    const jsonOut = JSON.parse(result.stdout);
+    // Latter set envs override former ones, so secrets should be 2 and 4
+    expect(jsonOut['SECRET1']).toBe('this is the secret2');
+    expect(jsonOut['SECRET2']).toBeUndefined();
+    expect(jsonOut['SECRET3']).toBeUndefined();
+    expect(jsonOut['SECRET4']).toBe('this is the secret4');
+  });
+  test('should output .env format', async () => {
+    const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
+
+    await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
+      await vaultOps.addSecret(vault, 'SECRET1', 'this is the secret1');
+      await vaultOps.addSecret(vault, 'SECRET2', 'this is the secret2');
+      await vaultOps.mkdir(vault, 'dir1');
+      await vaultOps.addSecret(vault, 'dir1/SECRET3', 'this is the secret3');
+      await vaultOps.addSecret(vault, 'dir1/SECRET4', 'this is the secret4');
+    });
+
+    command = [
+      'secrets',
+      'env',
+      '-np',
+      dataDir,
+      '-e',
+      `${vaultName}:.`,
+      '--output-format',
+      'dotenv',
+    ];
+
+    const result = await testUtils.pkExec([...command]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('SECRET1="this is the secret1"');
+    expect(result.stdout).toContain('SECRET2="this is the secret2"');
+    expect(result.stdout).toContain('SECRET3="this is the secret3"');
+    expect(result.stdout).toContain('SECRET4="this is the secret4"');
+  });
+  test('should output json format', async () => {
+    const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
+
+    await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
+      await vaultOps.addSecret(vault, 'SECRET1', 'this is the secret1');
+      await vaultOps.addSecret(vault, 'SECRET2', 'this is the secret2');
+      await vaultOps.mkdir(vault, 'dir1');
+      await vaultOps.addSecret(vault, 'dir1/SECRET3', 'this is the secret3');
+      await vaultOps.addSecret(vault, 'dir1/SECRET4', 'this is the secret4');
+    });
+
+    command = [
+      'secrets',
+      'env',
+      '-np',
+      dataDir,
+      '-e',
+      `${vaultName}:.`,
+      '--output-format',
+      'json',
+    ];
+
+    const result = await testUtils.pkExec([...command]);
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      SECRET1: 'this is the secret1',
+      SECRET2: 'this is the secret2',
+      SECRET3: 'this is the secret3',
+      SECRET4: 'this is the secret4',
+    });
+  });
+  test('should output prepend format', async () => {
+    const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
+
+    await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
+      await vaultOps.addSecret(vault, 'SECRET1', 'this is the secret1');
+      await vaultOps.addSecret(vault, 'SECRET2', 'this is the secret2');
+      await vaultOps.mkdir(vault, 'dir1');
+      await vaultOps.addSecret(vault, 'dir1/SECRET3', 'this is the secret3');
+      await vaultOps.addSecret(vault, 'dir1/SECRET4', 'this is the secret4');
+    });
+
+    command = [
+      'secrets',
+      'env',
+      '-np',
+      dataDir,
+      '-e',
+      `${vaultName}:.`,
+      '--output-format',
+      'prepend',
+    ];
+
+    const result = await testUtils.pkExec([...command]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe(
+      'SECRET1="this is the secret1" SECRET2="this is the secret2" SECRET3="this is the secret3" SECRET4="this is the secret4"',
+    );
+  });
+});

--- a/tests/secrets/env.test.ts
+++ b/tests/secrets/env.test.ts
@@ -292,7 +292,7 @@ describe('commandEnv', () => {
     expect(jsonOut['SECRET3']).toBeUndefined();
     expect(jsonOut['SECRET4']).toBe('this is the secret4');
   });
-  test('should output .env format', async () => {
+  test('should output human format', async () => {
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
 
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
@@ -310,7 +310,36 @@ describe('commandEnv', () => {
       dataDir,
       '-e',
       `${vaultName}:.`,
-      '--env-format',
+      '--format',
+      'human',
+    ];
+
+    const result = await testUtils.pkExec([...command]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('SECRET1="this is the secret1"');
+    expect(result.stdout).toContain('SECRET2="this is the secret2"');
+    expect(result.stdout).toContain('SECRET3="this is the secret3"');
+    expect(result.stdout).toContain('SECRET4="this is the secret4"');
+  });
+  test('should output dotenv format', async () => {
+    const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
+
+    await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
+      await vaultOps.addSecret(vault, 'SECRET1', 'this is the secret1');
+      await vaultOps.addSecret(vault, 'SECRET2', 'this is the secret2');
+      await vaultOps.mkdir(vault, 'dir1');
+      await vaultOps.addSecret(vault, 'dir1/SECRET3', 'this is the secret3');
+      await vaultOps.addSecret(vault, 'dir1/SECRET4', 'this is the secret4');
+    });
+
+    command = [
+      'secrets',
+      'env',
+      '-np',
+      dataDir,
+      '-e',
+      `${vaultName}:.`,
+      '--format',
       'dotenv',
     ];
 
@@ -339,7 +368,7 @@ describe('commandEnv', () => {
       dataDir,
       '-e',
       `${vaultName}:.`,
-      '--env-format',
+      '--format',
       'json',
     ];
 
@@ -370,7 +399,7 @@ describe('commandEnv', () => {
       dataDir,
       '-e',
       `${vaultName}:.`,
-      '--env-format',
+      '--format',
       'prepend',
     ];
 


### PR DESCRIPTION
### Description

This PR addresses adding the `secrets env` command to the cli

### Issues Fixed

* Fixes #31 

### Tasks

- [x] 1. parse input for selecting desired secrets from vaults
- [x] 2. obtain secrets from the Polykey agent
- [x] 3. ability to output env variables in selectable formats
- [x] 4. ability to run commands with env variables only for the duration of that command
- [x] 5. ability to have the running command replace the current process that invoked it.
- [x] 6. created tests to demonstrate and test functionality

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
