### PR TITLE
Upgrade to Node 20

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -248,6 +248,7 @@ integration:builds:
         .#packages.x86_64-linux.executable \
         .#packages.x86_64-windows.executable \
         .#packages.x86_64-darwin.executable \
+        .#packages.aarch64-darwin.executable \
       )";
       cp -r $(echo $builds | tr '\n' ' ') ./builds/;
   artifacts:

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,9 @@
       # The target systems and their vercel/pkg mapping
       systems = {
         "x86_64-linux" = [ "linux" "x64" ];
+        "aarch64-linux" = [ "linux" "arm64" ];
         "x86_64-windows" = [ "win32" "x64" ];
+        "aarch64-windows" = [ "win32" "arm64" ];
         "x86_64-darwin" = [ "darwin" "x64" ];
         "aarch64-darwin" = [ "darwin" "arm64" ];
       };
@@ -94,7 +96,7 @@
 
         shell = { ci ? false }: with pkgs; pkgs.mkShell {
           nativeBuildInputs = [
-            nodejs
+            nodejs_20
             prefetch-npm-deps
             shellcheck
             gitAndTools.gh

--- a/flake.nix
+++ b/flake.nix
@@ -12,9 +12,7 @@
       # The target systems and their vercel/pkg mapping
       systems = {
         "x86_64-linux" = [ "linux" "x64" ];
-        "aarch64-linux" = [ "linux" "arm64" ];
         "x86_64-windows" = [ "win32" "x64" ];
-        "aarch64-windows" = [ "win32" "arm64" ];
         "x86_64-darwin" = [ "darwin" "x64" ];
         "aarch64-darwin" = [ "darwin" "arm64" ];
       };

--- a/npmDepsHash
+++ b/npmDepsHash
@@ -1,1 +1,1 @@
-sha256-zPxb3VUEeVjeWsIpBlszq3RWeZh3/0ICKRw/SyMCKsw=
+sha256-buIzGNjR5CMM7BNlw5srJtVTSH/6Ru+UsMeXeNOjgZ4=

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/node": "^20.5.7",
         "@typescript-eslint/eslint-plugin": "^5.61.0",
         "@typescript-eslint/parser": "^5.61.0",
-        "@yao-pkg/pkg": "^5.9.1",
+        "@yao-pkg/pkg": "^5.11.4",
         "commander": "^8.3.0",
         "cross-env": "^7.0.3",
         "esbuild": "0.19.4",
@@ -2356,15 +2356,15 @@
       }
     },
     "node_modules/@yao-pkg/pkg": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@yao-pkg/pkg/-/pkg-5.9.1.tgz",
-      "integrity": "sha512-FzdeygSMS6XxHapvdoWpNvYADRJ6QoZdv5dWDapgI8br744ND7x2KC2Pn2/WisO8yZFVwweV0QlgpxR9aJiE8A==",
+      "version": "5.11.4",
+      "resolved": "https://registry.npmjs.org/@yao-pkg/pkg/-/pkg-5.11.4.tgz",
+      "integrity": "sha512-2ev8PlyCdDexFiLoUw/AGgZoR0zMfdm4CiTXZ7EEWAaGsWn7JRIAqLerwHOzMqKZNFwXUr3ze723NxpWSG+dgw==",
       "dev": true,
       "dependencies": {
         "@babel/generator": "7.23.0",
         "@babel/parser": "7.23.0",
         "@babel/types": "7.23.0",
-        "@yao-pkg/pkg-fetch": "3.5.4",
+        "@yao-pkg/pkg-fetch": "3.5.9",
         "chalk": "^4.1.2",
         "fs-extra": "^9.1.0",
         "globby": "^11.1.0",
@@ -2381,9 +2381,9 @@
       }
     },
     "node_modules/@yao-pkg/pkg-fetch": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/@yao-pkg/pkg-fetch/-/pkg-fetch-3.5.4.tgz",
-      "integrity": "sha512-dygzVkfv6XJqNaVaGoPil7E3SzzhzGLAcC2mLahYVs5JeSHZhCaKqQDfSz9UPoYmGLKqK2zobfQtwy1murPJvA==",
+      "version": "3.5.9",
+      "resolved": "https://registry.npmjs.org/@yao-pkg/pkg-fetch/-/pkg-fetch-3.5.9.tgz",
+      "integrity": "sha512-usMwwqFCd2B7k+V87u6kiTesyDSlw+3LpiuYBWe+UgryvSOk/NXjx3XVCub8hQoi0bCREbdQ6NDBqminyHJJrg==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
@@ -9082,9 +9082,9 @@
       "dev": true
     },
     "node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@types/node": "^20.5.7",
     "@typescript-eslint/eslint-plugin": "^5.61.0",
     "@typescript-eslint/parser": "^5.61.0",
-    "@yao-pkg/pkg": "^5.9.1",
+    "@yao-pkg/pkg": "^5.11.4",
     "commander": "^8.3.0",
     "cross-env": "^7.0.3",
     "esbuild": "0.19.4",

--- a/scripts/brew-install.sh
+++ b/scripts/brew-install.sh
@@ -10,5 +10,5 @@ export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
 export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_ANALYTICS=1
 
-brew reinstall node@18
-brew link --overwrite node@18
+brew reinstall node@20
+brew link --overwrite node@20

--- a/scripts/choco-install.ps1
+++ b/scripts/choco-install.ps1
@@ -23,10 +23,10 @@ if ( $null -eq $env:ChocolateyInstall ) {
 New-Item -Path "${PSScriptRoot}\..\tmp\chocolatey" -ItemType "directory" -ErrorAction:SilentlyContinue
 choco source add --name="cache" --source="${PSScriptRoot}\..\tmp\chocolatey" --priority=1
 
-# Install nodejs v18.15.0 (will use cache if exists)
+# Install nodejs v20.5.1 (will use cache if exists)
 $nodejs = "nodejs.install"
-choco install "$nodejs" --version="18.15.0" --require-checksums -y
+choco install "$nodejs" --version="20.5.1" --require-checksums -y
 # Internalise nodejs to cache if doesn't exist
-if ( -not (Test-Path -Path "${PSScriptRoot}\..\tmp\chocolatey\$nodejs\$nodejs.18.15.0.nupkg" -PathType Leaf) ) {
+if ( -not (Test-Path -Path "${PSScriptRoot}\..\tmp\chocolatey\$nodejs\$nodejs.20.5.1.nupkg" -PathType Leaf) ) {
   Save-ChocoPackage -PackageName $nodejs
 }

--- a/tests/identities/authenticateAuthenticated.test.ts
+++ b/tests/identities/authenticateAuthenticated.test.ts
@@ -120,7 +120,7 @@ describe('authenticate/authenticated', () => {
     let exitCode: number;
     // Authenticate
     // Invalid provider
-    ({ exitCode } = await testUtils.pkStdio(
+    ({ exitCode } = await testUtils.pkExec(
       ['identities', 'authenticate', '', testToken.identityId],
       {
         env: {
@@ -133,16 +133,13 @@ describe('authenticate/authenticated', () => {
     expect(exitCode).toBe(sysexits.USAGE);
     // Authenticated
     // Invalid provider
-    ({ exitCode } = await testUtils.pkStdio(
-      ['identities', 'authenticate', ''],
-      {
-        env: {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
-        },
-        cwd: dataDir,
+    ({ exitCode } = await testUtils.pkExec(['identities', 'authenticate', ''], {
+      env: {
+        PK_NODE_PATH: nodePath,
+        PK_PASSWORD: password,
       },
-    ));
+      cwd: dataDir,
+    }));
     expect(exitCode).toBe(sysexits.USAGE);
   });
 });

--- a/tests/identities/claim.test.ts
+++ b/tests/identities/claim.test.ts
@@ -103,7 +103,7 @@ describe('claim', () => {
     // Expect(claim!.payload.data.type).toBe('identity');
   });
   test('cannot claim unauthenticated identities', async () => {
-    const { exitCode } = await testUtils.pkStdio(
+    const { exitCode } = await testUtils.pkExec(
       [
         'identities',
         'claim',
@@ -122,7 +122,7 @@ describe('claim', () => {
   test('should fail on invalid inputs', async () => {
     let exitCode: number;
     // Invalid provider
-    ({ exitCode } = await testUtils.pkStdio(
+    ({ exitCode } = await testUtils.pkExec(
       ['identities', 'claim', `:${testToken.identityId}`],
       {
         env: {
@@ -134,7 +134,7 @@ describe('claim', () => {
     ));
     expect(exitCode).toBe(sysexits.USAGE);
     // Invalid identity
-    ({ exitCode } = await testUtils.pkStdio(
+    ({ exitCode } = await testUtils.pkExec(
       ['identities', 'claim', `${testToken.providerId}:`],
       {
         env: {

--- a/tests/identities/discoverGet.test.ts
+++ b/tests/identities/discoverGet.test.ts
@@ -284,7 +284,7 @@ describe('discover/get', () => {
   });
   test('should fail on invalid inputs', async () => {
     // Discover
-    const { exitCode } = await testUtils.pkStdio(
+    const { exitCode } = await testUtils.pkExec(
       ['identities', 'discover', 'invalid'],
       {
         env: {
@@ -296,7 +296,7 @@ describe('discover/get', () => {
     );
     expect(exitCode).toBe(sysexits.USAGE);
     // Get
-    await testUtils.pkStdio(['identities', 'get', 'invalid'], {
+    await testUtils.pkExec(['identities', 'get', 'invalid'], {
       env: {
         PK_NODE_PATH: nodePath,
         PK_PASSWORD: password,

--- a/tests/identities/search.test.ts
+++ b/tests/identities/search.test.ts
@@ -361,7 +361,7 @@ describe('search', () => {
   test('should fail on invalid inputs', async () => {
     let exitCode: number;
     // Invalid identity id
-    ({ exitCode } = await testUtils.pkStdio(
+    ({ exitCode } = await testUtils.pkExec(
       ['identities', 'search', '--identity-id', ''],
       {
         env: {
@@ -373,7 +373,7 @@ describe('search', () => {
     ));
     expect(exitCode).toBe(sysexits.USAGE);
     // Invalid auth identity id
-    ({ exitCode } = await testUtils.pkStdio(
+    ({ exitCode } = await testUtils.pkExec(
       ['identities', 'search', '--auth-identity-id', ''],
       {
         env: {
@@ -385,7 +385,7 @@ describe('search', () => {
     ));
     expect(exitCode).toBe(sysexits.USAGE);
     // Invalid value for limit
-    ({ exitCode } = await testUtils.pkStdio(
+    ({ exitCode } = await testUtils.pkExec(
       ['identities', 'search', '--limit', 'NaN'],
       {
         env: {

--- a/tests/identities/trustUntrustList.test.ts
+++ b/tests/identities/trustUntrustList.test.ts
@@ -274,7 +274,7 @@ describe('trust/untrust/list', () => {
       // belongs to and add it to our gestalt graph
       // This command should fail first time as we need to allow time for the
       // identity to be linked to a node in the node graph
-      ({ exitCode } = await testUtils.pkStdio(
+      ({ exitCode } = await testUtils.pkExec(
         ['identities', 'trust', providerString],
         {
           env: {
@@ -379,19 +379,16 @@ describe('trust/untrust/list', () => {
   test('should fail on invalid inputs', async () => {
     let exitCode: number;
     // Trust
-    ({ exitCode } = await testUtils.pkStdio(
-      ['identities', 'trust', 'invalid'],
-      {
-        env: {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
-        },
-        cwd: dataDir,
+    ({ exitCode } = await testUtils.pkExec(['identities', 'trust', 'invalid'], {
+      env: {
+        PK_NODE_PATH: nodePath,
+        PK_PASSWORD: password,
       },
-    ));
+      cwd: dataDir,
+    }));
     expect(exitCode).toBe(sysexits.USAGE);
     // Untrust
-    ({ exitCode } = await testUtils.pkStdio(
+    ({ exitCode } = await testUtils.pkExec(
       ['identities', 'untrust', 'invalid'],
       {
         env: {

--- a/tests/utils/exec.ts
+++ b/tests/utils/exec.ts
@@ -150,7 +150,9 @@ async function pk(args: Array<string>): Promise<any> {
  * Runs pk command functionally with mocked STDIO
  * Both stdout and stderr are the entire output including newlines
  * This can only be used serially, because the mocks it relies on are global singletons
- * If it is used concurrently, the mocking side effects can conflict
+ * If it is used concurrently, the mocking side effects can conflict.
+ * Note that because this does not launch Polykey in a subprocess, the `process.exitCode` of the main process is overriden.
+ * This should only be used for commands that are expected to exit with code 0.
  */
 async function pkStdio(
   args: Array<string> = [],
@@ -160,6 +162,7 @@ async function pkStdio(
   stdout: string;
   stderr: string;
 }> {
+  const lastExitCode = process.exitCode;
   const cwd =
     opts.cwd ??
     (await fs.promises.mkdtemp(path.join(globalThis.tmpDir, 'polykey-test-')));
@@ -221,6 +224,7 @@ async function pkStdio(
   mockProcessAddListener.mockRestore();
   mockProcessOnce.mockRestore();
   mockProcessOn.mockRestore();
+  process.exitCode = lastExitCode;
   return {
     exitCode,
     stdout,

--- a/utils.nix
+++ b/utils.nix
@@ -1,12 +1,12 @@
 { nix-gitignore
 , linkFarm
-, nodejs
+, nodejs_20
 , lib
 , fetchurl
 }:
 
 rec {
-  nodeVersion = builtins.elemAt (lib.versions.splitVersion nodejs.version) 0;
+  nodeVersion = builtins.elemAt (lib.versions.splitVersion nodejs_20.version) 0;
   # Filter source to only what's necessary for building
   src = nix-gitignore.gitignoreSource [
     # The `.git` itself should be ignored
@@ -33,18 +33,18 @@ rec {
   pkgBuilds = {
     "3.5" = {
       "linux-x64" = fetchurl {
-        url = "https://github.com/yao-pkg/pkg-fetch/releases/download/v3.5/node-v18.15.0-linux-x64";
-        sha256 = "0pwbh2wxvkhl57s1fb2rivfjay963f00hz98kh5nvs4r2brl2a2p";
+        url = "https://github.com/yao-pkg/pkg-fetch/releases/download/v3.5/node-v20.11.1-linux-x64";
+        sha256 = "0f065bb2ccfdedaa7889e04604516604c2d0c0a0d9d13869578a6b3916b9a93e";
       };
       "win32-x64" = fetchurl {
-        url = "https://github.com/yao-pkg/pkg-fetch/releases/download/v3.5/node-v18.15.0-win-x64";
-        sha256 = "04brqm5avx8crfg28w706r0hkm8jx5gyadq9knq67s7jwd8x9j50";
+        url = "https://github.com/yao-pkg/pkg-fetch/releases/download/v3.5/node-v20.11.1-win-x64";
+        sha256 = "140c377c2c91751832e673cb488724cbd003f01aa237615142cd2907f34fa1a2";
       };
       "macos-x64" = fetchurl {
-        url = "https://github.com/yao-pkg/pkg-fetch/releases/download/v3.5/node-v18.15.0-macos-x64";
-        sha256 = "0xbqbd6bdfd7qbf94575103n2awndlnfv013mc92scvshl015ffx";
+        url = "https://github.com/yao-pkg/pkg-fetch/releases/download/v3.5/node-v20.11.1-macos-x64";
+        sha256 = "1558a49dfea01ae42702a71eaa1c7a6479abde8b2778bc7cb4f9a65d65a0afa6";
       };
-      # No build for v18.15.0 macos-arm64 build
+      # No build for v20.11.1 macos-arm64 build
       # "macos-arm64" = fetchurl {
       #   url = "";
       #   sha256 = "";

--- a/utils.nix
+++ b/utils.nix
@@ -44,11 +44,10 @@ rec {
         url = "https://github.com/yao-pkg/pkg-fetch/releases/download/v3.5/node-v20.11.1-macos-x64";
         sha256 = "1558a49dfea01ae42702a71eaa1c7a6479abde8b2778bc7cb4f9a65d65a0afa6";
       };
-      # No build for v20.11.1 macos-arm64 build
-      # "macos-arm64" = fetchurl {
-      #   url = "";
-      #   sha256 = "";
-      # };
+      "macos-arm64" = fetchurl {
+        url = "https://github.com/yao-pkg/pkg-fetch/releases/download/v3.5/node-v20.11.1-macos-arm64";
+        sha256 = "1fa7f9e233820cfc5668ba21b70c463214f981fc69f1b8175b25dfa871451e26";
+      };
     };
   };
   pkgCachePath =
@@ -70,10 +69,9 @@ rec {
             name = fetchedName pkgBuild.macos-x64.name;
             path = pkgBuild.macos-x64;
           }
-          # No build for v18.15 macos-arm64 build
-          # {
-          #   name = fetchedName pkgBuild.macos-arm64.name;
-          #   path = pkgBuild.macos-arm64;
-          # }
+          {
+            name = fetchedName pkgBuild.macos-arm64.name;
+            path = pkgBuild.macos-arm64;
+          }
         ];
 }


### PR DESCRIPTION
### Description
This PR upgrades the Node version for all development environments to Node 20, and enables building of arm64 macos builds.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #111 

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Update `utils.nix` node package to `nodejs_20` for buildsp
- [x] 2. Update `flake.nix` `mkShell` inputs node package to `nodejs_20` for `nix develop` environments
- [x] 3. Update `scripts/choco-install.ps1` to use `nodev20.5.1`
- [x] 4. Update `scripts/brew-install.sh` to use `node@20`.
- [x] 5. Add macos Arm64 builds to `.gitlab-ci.yml`
- [x] 6. Docblock `utils.pkStdio` to warn usage when the expected `process.exitCode` is non-zero. 

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
