### PR TITLE
NixOS Module Configuration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,6 @@
 
             passwordFilePath = mkOption {
               type = with types; uniq str;
-              default = "/this/path/will/cause/a/failure/if/not/set";
               description = ''
               The path to the Polykey password file. This is required to be set for the module to work, otherwise this module will fail.
               '';
@@ -56,7 +55,6 @@
 
             passwordFilePath = mkOption {
               type = with types; uniq str;
-              default = "/this/path/will/cause/a/failure/if/not/set";
               description = ''
               The path to the Polykey password file. This is required to be set for the module to work, otherwise this module will fail.
               '';

--- a/src/agent/CommandStart.ts
+++ b/src/agent/CommandStart.ts
@@ -12,7 +12,7 @@ import type { DeepPartial } from 'polykey/dist/types';
 import type { RecoveryCode } from 'polykey/dist/keys/types';
 import childProcess from 'child_process';
 import process from 'process';
-import * as fs from 'fs';
+import fs from 'fs';
 import config from 'polykey/dist/config';
 import * as keysErrors from 'polykey/dist/keys/errors';
 import * as polykeyEvents from 'polykey/dist/events';

--- a/src/agent/CommandStart.ts
+++ b/src/agent/CommandStart.ts
@@ -12,6 +12,7 @@ import type { DeepPartial } from 'polykey/dist/types';
 import type { RecoveryCode } from 'polykey/dist/keys/types';
 import childProcess from 'child_process';
 import process from 'process';
+import * as fs from 'fs';
 import config from 'polykey/dist/config';
 import * as keysErrors from 'polykey/dist/keys/errors';
 import * as polykeyEvents from 'polykey/dist/events';
@@ -28,6 +29,7 @@ class CommandStart extends CommandPolykey {
     this.name('start');
     this.description('Start the Polykey Agent');
     this.addOption(binOptions.recoveryCodeFile);
+    this.addOption(binOptions.recoveryCodeOutFile);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
     this.addOption(binOptions.agentHost);
@@ -265,12 +267,18 @@ class CommandStart extends CommandPolykey {
           type: options.format === 'json' ? 'json' : 'dict',
           data: {
             ...statusLiveData!,
-            ...(recoveryCodeOut != null
+            ...(recoveryCodeOut != null && options.recoveryCodeOutFile == null
               ? { recoveryCode: recoveryCodeOut }
               : {}),
           },
         }),
       );
+      if (options.recoveryCodeOutFile != null && recoveryCodeOut != null) {
+        await fs.promises.writeFile(
+          options.recoveryCodeOutFile,
+          recoveryCodeOut,
+        );
+      }
     });
   }
 }

--- a/src/bootstrap/CommandBootstrap.ts
+++ b/src/bootstrap/CommandBootstrap.ts
@@ -1,4 +1,5 @@
 import process from 'process';
+import * as fs from 'fs';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
@@ -10,6 +11,7 @@ class CommandBootstrap extends CommandPolykey {
     this.name('bootstrap');
     this.description('Bootstrap Keynode State');
     this.addOption(binOptions.recoveryCodeFile);
+    this.addOption(binOptions.recoveryCodeOutFile);
     this.addOption(binOptions.fresh);
     this.addOption(binOptions.privateKeyFile);
     this.addOption(binOptions.passwordOpsLimit);
@@ -37,14 +39,22 @@ class CommandBootstrap extends CommandPolykey {
         logger: this.logger,
       });
       this.logger.info(`Bootstrapped ${options.nodePath}`);
-      process.stdout.write(
-        binUtils.outputFormatter({
-          type: options.format === 'json' ? 'json' : 'dict',
-          data: {
-            recoveryCode: recoveryCodeOut,
-          },
-        }),
-      );
+
+      if (options.recoveryCodeOutFile == null) {
+        process.stdout.write(
+          binUtils.outputFormatter({
+            type: options.format === 'json' ? 'json' : 'dict',
+            data: {
+              recoveryCode: recoveryCodeOut,
+            },
+          }),
+        );
+      } else if (recoveryCodeOut != null) {
+        await fs.promises.writeFile(
+          options.recoveryCodeOutFile,
+          recoveryCodeOut,
+        );      
+      }
     });
   }
 }

--- a/src/bootstrap/CommandBootstrap.ts
+++ b/src/bootstrap/CommandBootstrap.ts
@@ -1,5 +1,5 @@
 import process from 'process';
-import * as fs from 'fs';
+import fs from 'fs';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
@@ -53,7 +53,7 @@ class CommandBootstrap extends CommandPolykey {
         await fs.promises.writeFile(
           options.recoveryCodeOutFile,
           recoveryCodeOut,
-        );      
+        );
       }
     });
   }

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -105,6 +105,11 @@ const recoveryCodeFile = new commander.Option(
   'Path to Recovery Code',
 );
 
+const recoveryCodeOutFile = new commander.Option(
+  '-rcof, --recovery-code-out-file <path>',
+  'Path to output recovery code. Only used if a `RecoveryCode` is generated.',
+);
+
 const background = new commander.Option(
   '-b, --background',
   'Starts the agent as a background process',
@@ -240,6 +245,7 @@ export {
   agentPort,
   connConnectTime,
   recoveryCodeFile,
+  recoveryCodeOutFile,
   passwordFile,
   passwordNewFile,
   background,

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -102,12 +102,12 @@ const passwordNewFile = new commander.Option(
 
 const recoveryCodeFile = new commander.Option(
   '-rcf, --recovery-code-file <path>',
-  'Path to Recovery Code',
+  'Path to a file used to load the Recovery Code from',
 );
 
 const recoveryCodeOutFile = new commander.Option(
   '-rcof, --recovery-code-out-file <path>',
-  'Path to output recovery code. Only used if a `RecoveryCode` is generated.',
+  'Path used to write the Recovery Code if one was generated, if none was generated then this is ignored',
 );
 
 const background = new commander.Option(

--- a/src/utils/processors.ts
+++ b/src/utils/processors.ts
@@ -84,6 +84,10 @@ async function processPassword(
   let password: string | undefined;
   if (passwordFile != null) {
     try {
+      const stats = await fs.promises.stat(passwordFile);
+      const perms = '0' + (stats.mode & parseInt('777', 8)).toString(8);
+      if (perms !== '0600') throw new Error('Password file permissions unsafe, expected 0600 permissions');
+
       password = (await fs.promises.readFile(passwordFile, 'utf-8')).trim();
     } catch (e) {
       throw new errors.ErrorPolykeyCLIPasswordFileRead(e.message, {

--- a/src/utils/processors.ts
+++ b/src/utils/processors.ts
@@ -84,10 +84,6 @@ async function processPassword(
   let password: string | undefined;
   if (passwordFile != null) {
     try {
-      const stats = await fs.promises.stat(passwordFile);
-      const perms = '0' + (stats.mode & parseInt('777', 8)).toString(8);
-      if (perms !== '0600') throw new Error('Password file permissions unsafe, expected 0600 permissions');
-
       password = (await fs.promises.readFile(passwordFile, 'utf-8')).trim();
     } catch (e) {
       throw new errors.ErrorPolykeyCLIPasswordFileRead(e.message, {


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->
This PR adds a module to Polykey-CLI that allows for the automated activation of the Polykey Agent through a `systemd` service, both in user-space and system-wide space.

Two module configurations are provided, both a `programs` module and a `services` module. Fundamentally, both have the same configuration options. The main difference here is that the programs module gives each user their own unit service that can be enabled on a per-user basis, while the system service can be managed by a root user, or members of the group `polykey` (a lot like Docker daemon).

At the moment, the module will require the user to provide a path to the password/recovery-code files, and will otherwise fail if not provided.

In the future by default, the system level service will read from a directory under `/var/lib/polykey` for the relevant password and recovery code files, and under the user-level service, will read from `~/.config/polykey`. These paths may be overwritten in the module configuration.

![feature-module Spec excalidraw](https://github.com/MatrixAI/Polykey-CLI/assets/49110391/f78d634d-9f90-4c40-9f9a-12945c372366)

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #143 

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Implement the service module
- [x] 2. Implement the programs module
- [x] 3. Add minor finishing touches
- [x] 3. Test module and expected behaviour

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
