### PR TITLE
Expand `secrets env --env-format` format choices

### DIFF
--- a/src/secrets/CommandEnv.ts
+++ b/src/secrets/CommandEnv.ts
@@ -35,6 +35,7 @@ class CommandEnv extends CommandPolykey {
         envInvalid: 'error' | 'warn' | 'ignore';
         envDuplicate: 'keep' | 'overwrite' | 'warn' | 'error';
         envFormat:
+          | 'platform'
           | 'human'
           | 'dotenv'
           | 'dotbat'
@@ -176,9 +177,9 @@ class CommandEnv extends CommandPolykey {
         await pkClient.stop();
 
         // Here we want to switch between the different usages
+        const platform = os.platform();
         if (cmd != null) {
           // If a cmd is| provided then we default to exec it
-          const platform = os.platform();
           switch (platform) {
             case 'linux':
             // Fallthrough
@@ -204,7 +205,17 @@ class CommandEnv extends CommandPolykey {
           }
         } else {
           // Otherwise we switch between output formats
-          switch (envFormat) {
+          // If set to platform then we need to infer the format
+          let format = envFormat;
+          if (envFormat === 'platform') {
+            const platformFormatMap = {
+              darwin: 'dotenv',
+              linux: 'dotenv',
+              win32: 'dotbat',
+            };
+            format = platformFormatMap[platform] ?? 'dotenv';
+          }
+          switch (format) {
             case 'human':
             // Fallthrough
             case 'dotenv':

--- a/src/secrets/CommandEnv.ts
+++ b/src/secrets/CommandEnv.ts
@@ -11,15 +11,6 @@ import * as binOptions from '../utils/options';
 class CommandEnv extends CommandPolykey {
   constructor(...args: ConstructorParameters<typeof CommandPolykey>) {
     super(...args);
-
-    // Modify the --format choices to include `dotenv` and `prepend`
-    // @ts-ignore: missing type for `options`
-    const formatOption = this.options.filter((v) => v.short === '-f')[0];
-    if (formatOption == null) {
-      utils.never('The -f --format option should exist');
-    }
-    formatOption.argChoices.push('dotenv', 'prepend');
-
     this.name('env');
     this.description(
       `Run a command with the given secrets and env variables. If no command is specified then the variables are printed to stdout in the format specified by env-format.\n\nWhen selecting secrets with --env secrets with invalid names can be selected. By default when these are encountered then the command will throw an error. This behaviour can be modified with '--env-invalid'. the invalid name can be silently dropped with 'ignore' or logged out with 'warn'\n\nDuplicate secret names can be specified, by default with 'overwrite' the env variable will be overwritten with the latest found secret of that name. It can be specified to 'keep' the first found secret of that name, 'error' to throw if there is a duplicate and 'warn' to log a warning while overwriting.`,
@@ -28,6 +19,7 @@ class CommandEnv extends CommandPolykey {
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
     this.addOption(binOptions.envVariables);
+    this.addOption(binOptions.envFormat);
     this.addOption(binOptions.envInvalid);
     this.addOption(binOptions.envDuplicate);
     this.argument('[cmd] [argv...]', 'command and arguments');
@@ -37,12 +29,12 @@ class CommandEnv extends CommandPolykey {
         env: envVariables,
         envInvalid,
         envDuplicate,
-        format,
+        envFormat,
       }: {
         env: Array<[string, string, string?]>;
         envInvalid: 'error' | 'warn' | 'ignore';
         envDuplicate: 'keep' | 'overwrite' | 'warn' | 'error';
-        format: 'human' | 'dotenv' | 'json' | 'prepend';
+        envFormat: 'human' | 'dotenv' | 'json' | 'prepend';
       } = options;
 
       // There are a few stages here
@@ -191,7 +183,7 @@ class CommandEnv extends CommandPolykey {
           }
         } else {
           // Otherwise we switch between output formats
-          switch (format) {
+          switch (envFormat) {
             case 'human':
             // Fallthrough
             case 'dotenv':

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -211,8 +211,17 @@ const envFormat = new commander.Option(
   '-ef --env-format <envFormat>',
   'Select how the env variables are formatted on stdout if no command is specified',
 )
-  .choices(['human', 'json', 'dotenv', 'prepend'])
-  .default('human');
+  .choices([
+    'platform',
+    'human',
+    'json',
+    'dotenv',
+    'dotbat',
+    'dotps',
+    'prepend',
+    'prependCmd',
+  ])
+  .default('platform');
 
 const envInvalid = new commander.Option(
   '-ei --env-invalid <envInvalid>',

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -207,6 +207,13 @@ const envVariables = new commander.Option('-e --env <envs...>', 'specify envs')
     },
   );
 
+const envFormat = new commander.Option(
+  '-ef --env-format <envFormat>',
+  'Select how the env variables are formatted on stdout if no command is specified',
+)
+  .choices(['human', 'json', 'dotenv', 'prepend'])
+  .default('human');
+
 const envInvalid = new commander.Option(
   '-ei --env-invalid <envInvalid>',
   'How invalid env variable names are handled when retrieving secrets. `error` will throw, `warn` will log a warning and drop and `ignore` will silently drop.',
@@ -250,6 +257,7 @@ export {
   depth,
   commitId,
   envVariables,
+  envFormat,
   envInvalid,
   envDuplicate,
 };

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -211,16 +211,7 @@ const envFormat = new commander.Option(
   '-ef --env-format <envFormat>',
   'Select how the env variables are formatted on stdout if no command is specified',
 )
-  .choices([
-    'platform',
-    'human',
-    'json',
-    'dotenv',
-    'dotbat',
-    'dotps',
-    'prepend',
-    'prependCmd',
-  ])
+  .choices(['platform', 'json', 'unix', 'cmd', 'powershell'])
   .default('platform');
 
 const envInvalid = new commander.Option(

--- a/tests/secrets/env.test.ts
+++ b/tests/secrets/env.test.ts
@@ -310,7 +310,7 @@ describe('commandEnv', () => {
       dataDir,
       '-e',
       `${vaultName}:.`,
-      '--format',
+      '--env-format',
       'human',
     ];
 
@@ -339,7 +339,7 @@ describe('commandEnv', () => {
       dataDir,
       '-e',
       `${vaultName}:.`,
-      '--format',
+      '--env-format',
       'dotenv',
     ];
 
@@ -368,7 +368,7 @@ describe('commandEnv', () => {
       dataDir,
       '-e',
       `${vaultName}:.`,
-      '--format',
+      '--env-format',
       'json',
     ];
 
@@ -399,7 +399,7 @@ describe('commandEnv', () => {
       dataDir,
       '-e',
       `${vaultName}:.`,
-      '--format',
+      '--env-format',
       'prepend',
     ];
 

--- a/tests/secrets/env.test.ts
+++ b/tests/secrets/env.test.ts
@@ -68,6 +68,8 @@ describe('commandEnv', () => {
       dataDir,
       '-e',
       `${vaultName}:SECRET`,
+      '--env-format',
+      'human',
       '--',
       'node',
       '-e',
@@ -95,6 +97,8 @@ describe('commandEnv', () => {
       '-e',
       `${vaultName}:SECRET1`,
       `${vaultName}:SECRET2`,
+      '--env-format',
+      'human',
       '--',
       'node',
       '-e',
@@ -124,6 +128,8 @@ describe('commandEnv', () => {
       dataDir,
       '-e',
       `${vaultName}:dir1`,
+      '--env-format',
+      'human',
       '--',
       'node',
       '-e',
@@ -151,6 +157,8 @@ describe('commandEnv', () => {
       dataDir,
       '-e',
       `${vaultName}:SECRET=SECRET_NEW`,
+      '--env-format',
+      'human',
       '--',
       'node',
       '-e',
@@ -179,6 +187,8 @@ describe('commandEnv', () => {
       dataDir,
       '-e',
       `${vaultName}:dir1=SECRET_NEW`,
+      '--env-format',
+      'human',
       '--',
       'node',
       '-e',
@@ -212,6 +222,8 @@ describe('commandEnv', () => {
       `${vaultName}:SECRET1`,
       `${vaultName}:SECRET2`,
       `${vaultName}:dir1`,
+      '--env-format',
+      'human',
       '--',
       'node',
       '-e',
@@ -240,6 +252,8 @@ describe('commandEnv', () => {
       dataDir,
       '-e',
       `${vaultName}:SECRET1`,
+      '--env-format',
+      'human',
       '--',
       'node',
       '-e',
@@ -277,6 +291,8 @@ describe('commandEnv', () => {
       `${vaultName}:SECRET2=SECRET1`,
       `${vaultName}:SECRET3=SECRET4`,
       `${vaultName}:dir1`,
+      '--env-format',
+      'human',
       '--',
       'node',
       '-e',
@@ -322,15 +338,24 @@ describe('commandEnv', () => {
     expect(result.stdout).toContain('SECRET4="this is the secret4"');
   });
   test('should output dotenv format', async () => {
-    const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
+    const vaultId1 = await polykeyAgent.vaultManager.createVault(
+      `${vaultName}1`,
+    );
+    const vaultId2 = await polykeyAgent.vaultManager.createVault(
+      `${vaultName}2`,
+    );
 
-    await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
-      await vaultOps.addSecret(vault, 'SECRET1', 'this is the secret1');
-      await vaultOps.addSecret(vault, 'SECRET2', 'this is the secret2');
-      await vaultOps.mkdir(vault, 'dir1');
-      await vaultOps.addSecret(vault, 'dir1/SECRET3', 'this is the secret3');
-      await vaultOps.addSecret(vault, 'dir1/SECRET4', 'this is the secret4');
-    });
+    await polykeyAgent.vaultManager.withVaults(
+      [vaultId1, vaultId2],
+      async (vault1, vault2) => {
+        await vaultOps.addSecret(vault1, 'SECRET1', 'this is the secret1');
+        await vaultOps.addSecret(vault2, 'SECRET2', 'this is the secret2');
+        await vaultOps.mkdir(vault1, 'dir1');
+        await vaultOps.mkdir(vault2, 'dir1');
+        await vaultOps.addSecret(vault1, 'dir1/SECRET3', 'this is the secret3');
+        await vaultOps.addSecret(vault2, 'dir1/SECRET4', 'this is the secret4');
+      },
+    );
 
     command = [
       'secrets',
@@ -338,17 +363,108 @@ describe('commandEnv', () => {
       '-np',
       dataDir,
       '-e',
-      `${vaultName}:.`,
+      `${vaultName}1:.`,
+      `${vaultName}2:.`,
       '--env-format',
       'dotenv',
     ];
 
     const result = await testUtils.pkExec([...command]);
     expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('# vault1:SECRET1');
     expect(result.stdout).toContain('SECRET1="this is the secret1"');
+    expect(result.stdout).toContain('# vault2:SECRET2');
     expect(result.stdout).toContain('SECRET2="this is the secret2"');
+    expect(result.stdout).toContain('# vault1:dir1/SECRET3');
     expect(result.stdout).toContain('SECRET3="this is the secret3"');
+    expect(result.stdout).toContain('# vault2:dir1/SECRET4');
     expect(result.stdout).toContain('SECRET4="this is the secret4"');
+  });
+  test('should output dotbat format', async () => {
+    const vaultId1 = await polykeyAgent.vaultManager.createVault(
+      `${vaultName}1`,
+    );
+    const vaultId2 = await polykeyAgent.vaultManager.createVault(
+      `${vaultName}2`,
+    );
+
+    await polykeyAgent.vaultManager.withVaults(
+      [vaultId1, vaultId2],
+      async (vault1, vault2) => {
+        await vaultOps.addSecret(vault1, 'SECRET1', 'this is the secret1');
+        await vaultOps.addSecret(vault2, 'SECRET2', 'this is the secret2');
+        await vaultOps.mkdir(vault1, 'dir1');
+        await vaultOps.mkdir(vault2, 'dir1');
+        await vaultOps.addSecret(vault1, 'dir1/SECRET3', 'this is the secret3');
+        await vaultOps.addSecret(vault2, 'dir1/SECRET4', 'this is the secret4');
+      },
+    );
+
+    command = [
+      'secrets',
+      'env',
+      '-np',
+      dataDir,
+      '-e',
+      `${vaultName}1:.`,
+      `${vaultName}2:.`,
+      '--env-format',
+      'dotbat',
+    ];
+
+    const result = await testUtils.pkExec([...command]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('REM vault1:SECRET1');
+    expect(result.stdout).toContain('set "SECRET1=this is the secret1"');
+    expect(result.stdout).toContain('REM vault2:SECRET2');
+    expect(result.stdout).toContain('set "SECRET2=this is the secret2"');
+    expect(result.stdout).toContain('REM vault1:dir1/SECRET3');
+    expect(result.stdout).toContain('set "SECRET3=this is the secret3"');
+    expect(result.stdout).toContain('REM vault2:dir1/SECRET4');
+    expect(result.stdout).toContain('set "SECRET4=this is the secret4"');
+  });
+  test('should output dotps format', async () => {
+    const vaultId1 = await polykeyAgent.vaultManager.createVault(
+      `${vaultName}1`,
+    );
+    const vaultId2 = await polykeyAgent.vaultManager.createVault(
+      `${vaultName}2`,
+    );
+
+    await polykeyAgent.vaultManager.withVaults(
+      [vaultId1, vaultId2],
+      async (vault1, vault2) => {
+        await vaultOps.addSecret(vault1, 'SECRET1', 'this is the secret1');
+        await vaultOps.addSecret(vault2, 'SECRET2', 'this is the secret2');
+        await vaultOps.mkdir(vault1, 'dir1');
+        await vaultOps.mkdir(vault2, 'dir1');
+        await vaultOps.addSecret(vault1, 'dir1/SECRET3', 'this is the secret3');
+        await vaultOps.addSecret(vault2, 'dir1/SECRET4', 'this is the secret4');
+      },
+    );
+
+    command = [
+      'secrets',
+      'env',
+      '-np',
+      dataDir,
+      '-e',
+      `${vaultName}1:.`,
+      `${vaultName}2:.`,
+      '--env-format',
+      'dotps',
+    ];
+
+    const result = await testUtils.pkExec([...command]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('# vault1:SECRET1');
+    expect(result.stdout).toContain(`$env:SECRET1 = 'this is the secret1'`);
+    expect(result.stdout).toContain('# vault2:SECRET2');
+    expect(result.stdout).toContain(`$env:SECRET2 = 'this is the secret2'`);
+    expect(result.stdout).toContain('# vault1:dir1/SECRET3');
+    expect(result.stdout).toContain(`$env:SECRET3 = 'this is the secret3'`);
+    expect(result.stdout).toContain('# vault2:dir1/SECRET4');
+    expect(result.stdout).toContain(`$env:SECRET4 = 'this is the secret4'`);
   });
   test('should output json format', async () => {
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
@@ -409,6 +525,34 @@ describe('commandEnv', () => {
       'SECRET1="this is the secret1" SECRET2="this is the secret2" SECRET3="this is the secret3" SECRET4="this is the secret4"',
     );
   });
+  test('should output prependCmd format', async () => {
+    const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
+
+    await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
+      await vaultOps.addSecret(vault, 'SECRET1', 'this is the secret1');
+      await vaultOps.addSecret(vault, 'SECRET2', 'this is the secret2');
+      await vaultOps.mkdir(vault, 'dir1');
+      await vaultOps.addSecret(vault, 'dir1/SECRET3', 'this is the secret3');
+      await vaultOps.addSecret(vault, 'dir1/SECRET4', 'this is the secret4');
+    });
+
+    command = [
+      'secrets',
+      'env',
+      '-np',
+      dataDir,
+      '-e',
+      `${vaultName}:.`,
+      '--env-format',
+      'prependCmd',
+    ];
+
+    const result = await testUtils.pkExec([...command]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe(
+      'set "SECRET1=this is the secret1" & set "SECRET2=this is the secret2" & set "SECRET3=this is the secret3" & set "SECRET4=this is the secret4"',
+    );
+  });
   test('testing valid and invalid rename inputs', async () => {
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
 
@@ -429,25 +573,14 @@ describe('commandEnv', () => {
 
     const invalid = ['123', '123abc', '123_123', '123_abc', '123 abc', ' '];
 
-    command = [
-      'secrets',
-      'env',
-      '-np',
-      dataDir,
-      '-e',
-      `${vaultName}:SECRET=one_123_ABC`,
-      '--',
-      'node',
-      '-e',
-      'console.log(JSON.stringify(process.env))',
-    ];
-
     // Checking valid
     const result = await testUtils.pkExec([
       'secrets',
       'env',
       '-np',
       dataDir,
+      '--env-format',
+      'human',
       '-e',
       ...valid.map((v) => `${vaultName}:SECRET=${v}`),
     ]);
@@ -460,6 +593,8 @@ describe('commandEnv', () => {
         'env',
         '-np',
         dataDir,
+        '--env-format',
+        'human',
         '-e',
         `${vaultName}:SECRET=${nameNew}`,
       ]);
@@ -479,6 +614,8 @@ describe('commandEnv', () => {
       'env',
       '-np',
       dataDir,
+      '--env-format',
+      'human',
       '-ei',
       'error',
       '-e',
@@ -499,6 +636,8 @@ describe('commandEnv', () => {
       'env',
       '-np',
       dataDir,
+      '--env-format',
+      'human',
       '-ei',
       'warn',
       '-e',
@@ -523,6 +662,8 @@ describe('commandEnv', () => {
       'env',
       '-np',
       dataDir,
+      '--env-format',
+      'human',
       '-ei',
       'ignore',
       '-e',
@@ -549,6 +690,8 @@ describe('commandEnv', () => {
       'env',
       '-np',
       dataDir,
+      '--env-format',
+      'human',
       '-ed',
       'error',
       '-e',
@@ -572,6 +715,8 @@ describe('commandEnv', () => {
       'env',
       '-np',
       dataDir,
+      '--env-format',
+      'human',
       '-ed',
       'warn',
       '-e',
@@ -597,6 +742,8 @@ describe('commandEnv', () => {
       'env',
       '-np',
       dataDir,
+      '--env-format',
+      'human',
       '-ed',
       'keep',
       '-e',
@@ -620,6 +767,8 @@ describe('commandEnv', () => {
       'env',
       '-np',
       dataDir,
+      '--env-format',
+      'human',
       '-ed',
       'overwrite',
       '-e',

--- a/tests/secrets/env.test.ts
+++ b/tests/secrets/env.test.ts
@@ -69,7 +69,7 @@ describe('commandEnv', () => {
       '-e',
       `${vaultName}:SECRET`,
       '--env-format',
-      'human',
+      'unix',
       '--',
       'node',
       '-e',
@@ -98,7 +98,7 @@ describe('commandEnv', () => {
       `${vaultName}:SECRET1`,
       `${vaultName}:SECRET2`,
       '--env-format',
-      'human',
+      'unix',
       '--',
       'node',
       '-e',
@@ -129,7 +129,7 @@ describe('commandEnv', () => {
       '-e',
       `${vaultName}:dir1`,
       '--env-format',
-      'human',
+      'unix',
       '--',
       'node',
       '-e',
@@ -158,7 +158,7 @@ describe('commandEnv', () => {
       '-e',
       `${vaultName}:SECRET=SECRET_NEW`,
       '--env-format',
-      'human',
+      'unix',
       '--',
       'node',
       '-e',
@@ -188,7 +188,7 @@ describe('commandEnv', () => {
       '-e',
       `${vaultName}:dir1=SECRET_NEW`,
       '--env-format',
-      'human',
+      'unix',
       '--',
       'node',
       '-e',
@@ -223,7 +223,7 @@ describe('commandEnv', () => {
       `${vaultName}:SECRET2`,
       `${vaultName}:dir1`,
       '--env-format',
-      'human',
+      'unix',
       '--',
       'node',
       '-e',
@@ -253,7 +253,7 @@ describe('commandEnv', () => {
       '-e',
       `${vaultName}:SECRET1`,
       '--env-format',
-      'human',
+      'unix',
       '--',
       'node',
       '-e',
@@ -292,7 +292,7 @@ describe('commandEnv', () => {
       `${vaultName}:SECRET3=SECRET4`,
       `${vaultName}:dir1`,
       '--env-format',
-      'human',
+      'unix',
       '--',
       'node',
       '-e',
@@ -327,7 +327,7 @@ describe('commandEnv', () => {
       '-e',
       `${vaultName}:.`,
       '--env-format',
-      'human',
+      'unix',
     ];
 
     const result = await testUtils.pkExec([...command]);
@@ -337,7 +337,7 @@ describe('commandEnv', () => {
     expect(result.stdout).toContain('SECRET3="this is the secret3"');
     expect(result.stdout).toContain('SECRET4="this is the secret4"');
   });
-  test('should output dotenv format', async () => {
+  test('should output unix format', async () => {
     const vaultId1 = await polykeyAgent.vaultManager.createVault(
       `${vaultName}1`,
     );
@@ -366,7 +366,7 @@ describe('commandEnv', () => {
       `${vaultName}1:.`,
       `${vaultName}2:.`,
       '--env-format',
-      'dotenv',
+      'unix',
     ];
 
     const result = await testUtils.pkExec([...command]);
@@ -380,7 +380,7 @@ describe('commandEnv', () => {
     expect(result.stdout).toContain('# vault2:dir1/SECRET4');
     expect(result.stdout).toContain('SECRET4="this is the secret4"');
   });
-  test('should output dotbat format', async () => {
+  test('should output cmd format', async () => {
     const vaultId1 = await polykeyAgent.vaultManager.createVault(
       `${vaultName}1`,
     );
@@ -409,7 +409,7 @@ describe('commandEnv', () => {
       `${vaultName}1:.`,
       `${vaultName}2:.`,
       '--env-format',
-      'dotbat',
+      'cmd',
     ];
 
     const result = await testUtils.pkExec([...command]);
@@ -423,7 +423,7 @@ describe('commandEnv', () => {
     expect(result.stdout).toContain('REM vault2:dir1/SECRET4');
     expect(result.stdout).toContain('set "SECRET4=this is the secret4"');
   });
-  test('should output dotps format', async () => {
+  test('should output powershell format', async () => {
     const vaultId1 = await polykeyAgent.vaultManager.createVault(
       `${vaultName}1`,
     );
@@ -452,7 +452,7 @@ describe('commandEnv', () => {
       `${vaultName}1:.`,
       `${vaultName}2:.`,
       '--env-format',
-      'dotps',
+      'powershell',
     ];
 
     const result = await testUtils.pkExec([...command]);
@@ -497,62 +497,6 @@ describe('commandEnv', () => {
       SECRET4: 'this is the secret4',
     });
   });
-  test('should output prepend format', async () => {
-    const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-
-    await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
-      await vaultOps.addSecret(vault, 'SECRET1', 'this is the secret1');
-      await vaultOps.addSecret(vault, 'SECRET2', 'this is the secret2');
-      await vaultOps.mkdir(vault, 'dir1');
-      await vaultOps.addSecret(vault, 'dir1/SECRET3', 'this is the secret3');
-      await vaultOps.addSecret(vault, 'dir1/SECRET4', 'this is the secret4');
-    });
-
-    command = [
-      'secrets',
-      'env',
-      '-np',
-      dataDir,
-      '-e',
-      `${vaultName}:.`,
-      '--env-format',
-      'prepend',
-    ];
-
-    const result = await testUtils.pkExec([...command]);
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout).toBe(
-      'SECRET1="this is the secret1" SECRET2="this is the secret2" SECRET3="this is the secret3" SECRET4="this is the secret4"',
-    );
-  });
-  test('should output prependCmd format', async () => {
-    const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-
-    await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
-      await vaultOps.addSecret(vault, 'SECRET1', 'this is the secret1');
-      await vaultOps.addSecret(vault, 'SECRET2', 'this is the secret2');
-      await vaultOps.mkdir(vault, 'dir1');
-      await vaultOps.addSecret(vault, 'dir1/SECRET3', 'this is the secret3');
-      await vaultOps.addSecret(vault, 'dir1/SECRET4', 'this is the secret4');
-    });
-
-    command = [
-      'secrets',
-      'env',
-      '-np',
-      dataDir,
-      '-e',
-      `${vaultName}:.`,
-      '--env-format',
-      'prependCmd',
-    ];
-
-    const result = await testUtils.pkExec([...command]);
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout).toBe(
-      'set "SECRET1=this is the secret1" & set "SECRET2=this is the secret2" & set "SECRET3=this is the secret3" & set "SECRET4=this is the secret4"',
-    );
-  });
   test('testing valid and invalid rename inputs', async () => {
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
 
@@ -580,7 +524,7 @@ describe('commandEnv', () => {
       '-np',
       dataDir,
       '--env-format',
-      'human',
+      'unix',
       '-e',
       ...valid.map((v) => `${vaultName}:SECRET=${v}`),
     ]);
@@ -594,7 +538,7 @@ describe('commandEnv', () => {
         '-np',
         dataDir,
         '--env-format',
-        'human',
+        'unix',
         '-e',
         `${vaultName}:SECRET=${nameNew}`,
       ]);
@@ -615,7 +559,7 @@ describe('commandEnv', () => {
       '-np',
       dataDir,
       '--env-format',
-      'human',
+      'unix',
       '-ei',
       'error',
       '-e',
@@ -637,7 +581,7 @@ describe('commandEnv', () => {
       '-np',
       dataDir,
       '--env-format',
-      'human',
+      'unix',
       '-ei',
       'warn',
       '-e',
@@ -663,7 +607,7 @@ describe('commandEnv', () => {
       '-np',
       dataDir,
       '--env-format',
-      'human',
+      'unix',
       '-ei',
       'ignore',
       '-e',
@@ -691,7 +635,7 @@ describe('commandEnv', () => {
       '-np',
       dataDir,
       '--env-format',
-      'human',
+      'unix',
       '-ed',
       'error',
       '-e',
@@ -716,7 +660,7 @@ describe('commandEnv', () => {
       '-np',
       dataDir,
       '--env-format',
-      'human',
+      'unix',
       '-ed',
       'warn',
       '-e',
@@ -743,7 +687,7 @@ describe('commandEnv', () => {
       '-np',
       dataDir,
       '--env-format',
-      'human',
+      'unix',
       '-ed',
       'keep',
       '-e',
@@ -768,7 +712,7 @@ describe('commandEnv', () => {
       '-np',
       dataDir,
       '--env-format',
-      'human',
+      'unix',
       '-ed',
       'overwrite',
       '-e',


### PR DESCRIPTION
### Description

This PR expands the avaliable formats for `polykey secrets env` command's `--env-format` option.

### Issues Fixed

* Fixes #144 

### Tasks

- [x] 1. address tasks In #144 

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
