### PR TITLE
Fix `identities authenticate` crash

### DIFF
--- a/npmDepsHash
+++ b/npmDepsHash
@@ -1,1 +1,1 @@
-sha256-/nogmxBBx/8+zSgaz/2N0yByJ30P9TnCTF0Dx69N4Qo=
+sha256-S68GU9VhfUQ5+iBWuGMoZrLCpAiyda3kvdR8c80QPL8=

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "nexpect": "^0.6.0",
         "node-gyp-build": "^4.4.0",
         "nodemon": "^3.0.1",
-        "polykey": "^1.2.1-alpha.49",
+        "polykey": "^1.2.1-alpha.50",
         "prettier": "^3.0.0",
         "shelljs": "^0.8.5",
         "shx": "^0.3.4",
@@ -7539,9 +7539,9 @@
       }
     },
     "node_modules/polykey": {
-      "version": "1.2.1-alpha.49",
-      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.2.1-alpha.49.tgz",
-      "integrity": "sha512-81kWTeJ6M8x6I/cbuHMEBFLo7K6cbT7NNNVPfNsnp8JJaeGQmwTAODCS4WGP7wqAC0NVTFRaqYMUpNVvbJ9RNQ==",
+      "version": "1.2.1-alpha.50",
+      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.2.1-alpha.50.tgz",
+      "integrity": "sha512-5lYAE4tsIXN00JTygDd9/Dvrr37T2uJxvpcK5UDG2Ju1/4rLadFaf5aC9ZeLAZyLWX14f7GAOuzGAycEVv9lcw==",
       "dev": true,
       "dependencies": {
         "@matrixai/async-cancellable": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "nexpect": "^0.6.0",
     "node-gyp-build": "^4.4.0",
     "nodemon": "^3.0.1",
-    "polykey": "^1.2.1-alpha.49",
+    "polykey": "^1.2.1-alpha.50",
     "prettier": "^3.0.0",
     "shelljs": "^0.8.5",
     "shx": "^0.3.4",

--- a/src/identities/CommandAuthenticate.ts
+++ b/src/identities/CommandAuthenticate.ts
@@ -72,7 +72,12 @@ class CommandAuthenticate extends CommandPolykey {
               this.logger.info(
                 'Use any additional additional properties to complete authentication',
               );
-              identitiesUtils.browser(message.request.url);
+              try {
+                await identitiesUtils.browser(message.request.url);
+              } catch (e) {
+                if (e.code !== 'ENOENT') throw e;
+                // Otherwise we ignore `ENOENT` as a failure to spawn a browser
+              }
               process.stdout.write(
                 binUtils.outputFormatter({
                   type: options.format === 'json' ? 'json' : 'dict',


### PR DESCRIPTION
### Description

This PR addresses crashing when using `identities authenticate` if it fails to open a browser.

### Issues Fixed

* Fixes: #76 

### Tasks

- [X] 1. Transplant `Browser` utility function from `Polykey` into `Polykey-CLI`.
- [X] 2. Fix `Browser` throw when failing to spawn browser rather than crashing the process.

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
