### PR TITLE
Adding discovery feedback functionality and commands

### DIFF
--- a/npmDepsHash
+++ b/npmDepsHash
@@ -1,1 +1,1 @@
-sha256-K8/scgUW02N0TteJ0SHTEHPxjsgkcbFK1v7U6k4BTTE=
+sha256-pckkN6xZ+tj+srTB5iHCwuHb3EFv0KiTPvFIGTTy1nQ=

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "nexpect": "^0.6.0",
         "node-gyp-build": "^4.4.0",
         "nodemon": "^3.0.1",
-        "polykey": "^1.2.3-alpha.4",
+        "polykey": "^1.2.3",
         "prettier": "^3.0.0",
         "shelljs": "^0.8.5",
         "shx": "^0.3.4",
@@ -7569,9 +7569,9 @@
       }
     },
     "node_modules/polykey": {
-      "version": "1.2.3-alpha.4",
-      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.2.3-alpha.4.tgz",
-      "integrity": "sha512-FWNWW3BOW+Ll0/cDO37TXcj/FZ/2VZ4eB3Tpozbo8+JyjiG0pbPQN04NoXFA7+B8F7rfdgHuNpV0mrldv2xaFQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.2.3.tgz",
+      "integrity": "sha512-PwsXsLMVZvv+yR+ry5+9Bzu10yXSvTczFM58GM4zpR1BxoLD7bwUj4gwJGnToAcufdUismpwHhb7CjT6QYYK/A==",
       "dev": true,
       "dependencies": {
         "@matrixai/async-cancellable": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "nexpect": "^0.6.0",
     "node-gyp-build": "^4.4.0",
     "nodemon": "^3.0.1",
-    "polykey": "^1.2.3-alpha.4",
+    "polykey": "^1.2.3",
     "prettier": "^3.0.0",
     "shelljs": "^0.8.5",
     "shx": "^0.3.4",

--- a/src/identities/CommandIdentities.ts
+++ b/src/identities/CommandIdentities.ts
@@ -7,6 +7,7 @@ import CommandDiscover from './CommandDiscover';
 import CommandGet from './CommandGet';
 import CommandList from './CommandList';
 import CommandPermissions from './CommandPermissions';
+import CommandQueue from './CommandQueue';
 import CommandSearch from './CommandSearch';
 import CommandTrust from './CommandTrust';
 import CommandUntrust from './CommandUntrust';
@@ -27,6 +28,7 @@ class CommandIdentities extends CommandPolykey {
     this.addCommand(new CommandGet(...args));
     this.addCommand(new CommandList(...args));
     this.addCommand(new CommandPermissions(...args));
+    this.addCommand(new CommandQueue(...args));
     this.addCommand(new CommandSearch(...args));
     this.addCommand(new CommandTrust(...args));
     this.addCommand(new CommandUntrust(...args));

--- a/src/identities/CommandQueue.ts
+++ b/src/identities/CommandQueue.ts
@@ -1,0 +1,85 @@
+import type PolykeyClient from 'polykey/dist/PolykeyClient';
+import CommandPolykey from '../CommandPolykey';
+import * as binOptions from '../utils/options';
+import * as binUtils from '../utils';
+import * as binProcessors from '../utils/processors';
+
+class CommandQueue extends CommandPolykey {
+  constructor(...args: ConstructorParameters<typeof CommandPolykey>) {
+    super(...args);
+    this.name('queue');
+    this.description('Prints out vertices queued for discovery');
+    this.addOption(binOptions.nodeId);
+    this.addOption(binOptions.clientHost);
+    this.addOption(binOptions.clientPort);
+    this.action(async (options) => {
+      const { default: PolykeyClient } = await import(
+        'polykey/dist/PolykeyClient'
+      );
+      const clientOptions = await binProcessors.processClientOptions(
+        options.nodePath,
+        options.nodeId,
+        options.clientHost,
+        options.clientPort,
+        this.fs,
+        this.logger.getChild(binProcessors.processClientOptions.name),
+      );
+      const auth = await binProcessors.processAuthentication(
+        options.passwordFile,
+        this.fs,
+      );
+      let pkClient: PolykeyClient;
+      this.exitHandlers.handlers.push(async () => {
+        if (pkClient != null) await pkClient.stop();
+      });
+      try {
+        pkClient = await PolykeyClient.createPolykeyClient({
+          nodeId: clientOptions.nodeId,
+          host: clientOptions.clientHost,
+          port: clientOptions.clientPort,
+          options: {
+            nodePath: options.nodePath,
+          },
+          logger: this.logger.getChild(PolykeyClient.name),
+        });
+        await binUtils.retryAuthentication(async (auth) => {
+          const readableStream =
+            await pkClient.rpcClient.methods.gestaltsDiscoveryQueue({
+              metadata: auth,
+            });
+          for await (const discoveryQueueInfo of readableStream) {
+            const sanitizedData = {
+              id: discoveryQueueInfo.id,
+              status: discoveryQueueInfo.status,
+              parameters: discoveryQueueInfo.parameters,
+              delay: discoveryQueueInfo.delay,
+              deadline: discoveryQueueInfo.deadline,
+              priority: discoveryQueueInfo.priority,
+              created: discoveryQueueInfo.created,
+              scheduled: discoveryQueueInfo.scheduled,
+            };
+            if (options.format === 'json') {
+              process.stdout.write(
+                binUtils.outputFormatter({
+                  type: 'json',
+                  data: sanitizedData,
+                }),
+              );
+            } else {
+              process.stdout.write(
+                binUtils.outputFormatter({
+                  type: 'dict',
+                  data: sanitizedData,
+                }),
+              );
+            }
+          }
+        }, auth);
+      } finally {
+        if (pkClient! != null) await pkClient.stop();
+      }
+    });
+  }
+}
+
+export default CommandQueue;

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -233,6 +233,11 @@ const envDuplicate = new commander.Option(
   .choices(['keep', 'overwrite', 'warn', 'error'])
   .default('overwrite');
 
+const discoveryMonitor = new commander.Option(
+  '--monitor',
+  'Enabling monitoring will cause discover to output discovery events as they happen and will exit once all children are processed',
+).default(false);
+
 export {
   nodePath,
   format,
@@ -266,4 +271,5 @@ export {
   envFormat,
   envInvalid,
   envDuplicate,
+  discoveryMonitor,
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -376,8 +376,9 @@ function outputFormatterDict(
     }
   } else {
     for (const key of data) {
-      const encodedKey = encodeEscapedWrapped(key);
-      keypairs.push([key, encodedKey]);
+      const safeKey = key ?? 'null';
+      const encodedKey = encodeEscapedWrapped(safeKey);
+      keypairs.push([safeKey, encodedKey]);
       if (encodedKey.length > maxKeyLength) {
         maxKeyLength = encodedKey.length;
       }
@@ -394,7 +395,7 @@ function outputFormatterDict(
 
     let value = data[originalKey];
     if (value == null) {
-      value = '';
+      value = 'null';
     } else if (typeof value == 'object') {
       output += `\n${outputFormatterDict(value, {
         padding: padding + 2,

--- a/tests/identities/discoverQueue.test.ts
+++ b/tests/identities/discoverQueue.test.ts
@@ -1,0 +1,96 @@
+import type { IdentityId, ProviderId } from 'polykey/dist/identities/types';
+import path from 'path';
+import fs from 'fs';
+import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
+import PolykeyAgent from 'polykey/dist/PolykeyAgent';
+import * as keysUtils from 'polykey/dist/keys/utils';
+import * as testUtils from '../utils';
+
+describe('discovery queue', () => {
+  const logger = new Logger('discovery queue test', LogLevel.WARN, [
+    new StreamHandler(),
+  ]);
+  const password = 'password';
+  let dataDir: string;
+  let nodePath: string;
+  let pkAgent: PolykeyAgent;
+  let node: PolykeyAgent;
+  beforeEach(async () => {
+    dataDir = await fs.promises.mkdtemp(
+      path.join(globalThis.tmpDir, 'polykey-test-'),
+    );
+    nodePath = path.join(dataDir, 'polykey');
+    pkAgent = await PolykeyAgent.createPolykeyAgent({
+      password,
+      options: {
+        nodePath,
+        agentServiceHost: '127.0.0.1',
+        clientServiceHost: '127.0.0.1',
+        keys: {
+          passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+          passwordMemLimit: keysUtils.passwordMemLimits.min,
+          strictMemoryLock: false,
+        },
+      },
+      logger,
+    });
+    // Set up a gestalt to modify the permissions of
+    const nodePathGestalt = path.join(dataDir, 'gestalt');
+    node = await PolykeyAgent.createPolykeyAgent({
+      password,
+      options: {
+        nodePath: nodePathGestalt,
+        agentServiceHost: '127.0.0.1',
+        clientServiceHost: '127.0.0.1',
+        keys: {
+          passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+          passwordMemLimit: keysUtils.passwordMemLimits.min,
+          strictMemoryLock: false,
+        },
+      },
+      logger,
+    });
+  });
+  afterEach(async () => {
+    await node.stop();
+    await pkAgent.stop();
+    await fs.promises.rm(dataDir, {
+      force: true,
+      recursive: true,
+    });
+  });
+
+  test('should return discovery queue', async () => {
+    // Scheduling discovery tasks
+    await pkAgent.taskManager.stopProcessing();
+    await pkAgent.discovery.queueDiscoveryByIdentity(
+      'provider' as ProviderId,
+      'identity1' as IdentityId,
+    );
+    await pkAgent.discovery.queueDiscoveryByIdentity(
+      'provider' as ProviderId,
+      'identity2' as IdentityId,
+    );
+    await pkAgent.discovery.queueDiscoveryByIdentity(
+      'provider' as ProviderId,
+      'identity3' as IdentityId,
+    );
+
+    // Doing test
+    const result = await testUtils.pkStdio(
+      ['identities', 'queue', '--format', 'json'],
+      {
+        env: {
+          PK_NODE_PATH: nodePath,
+          PK_PASSWORD: password,
+        },
+      },
+    );
+    expect(result.stdout).toIncludeMultiple([
+      'identity1',
+      'identity2',
+      'identity3',
+    ]);
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -110,7 +110,7 @@ describe('bin/utils', () => {
         type: 'dict',
         data: { key1: null, key2: undefined },
       }),
-    ).toBe('key1\t\nkey2\t\n');
+    ).toBe('key1\tnull\nkey2\tnull\n');
     // JSON
     expect(
       binUtils.outputFormatter({
@@ -154,8 +154,8 @@ describe('bin/utils', () => {
       }),
     ).toBe(
       'key1\t\n' +
-        '  key2\t\n' +
-        '  key3\t\n' +
+        '  key2\tnull\n' +
+        '  key3\tnull\n' +
         '  key4\tvalue\n' +
         'key5\tvalue\n' +
         'key6\t\n' +


### PR DESCRIPTION
### Description

This PR addresses the CLI side of the ENG-28 issue.

### Issues Fixed

* Fixes ENG-28
* Fixes ENG-292

### Tasks
- [x] 1. Expand `identities discover` command to have a `--blocking` flag that will wait for the back-grounded discovery tasks to complete. It will print out each step during this process.
- [x] 2. Add a `Identities queue` command that will output the current discovery queue.
- ~3. Add a `audit` domain `audit discovery` command that will output all discovery steps and events within the discovery domain. This includes the history as well.~ - Moving to a new PR

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
