### PR TITLE
Creating audit domain

### DIFF
--- a/npmDepsHash
+++ b/npmDepsHash
@@ -1,1 +1,1 @@
-sha256-aSQGZ+PTzc0GCs8SvMw6fnvx6BN20/l3C0h2ox3s7Mg=
+sha256-mto5sb8+L5pb0ZXGruJlNmPz3XU1fOSF14mh5VHoW7I=

--- a/npmDepsHash
+++ b/npmDepsHash
@@ -1,1 +1,1 @@
-sha256-mto5sb8+L5pb0ZXGruJlNmPz3XU1fOSF14mh5VHoW7I=
+sha256-3x+Xu52V6lAVNJ+DP0lcjz43/EHQs4IWuWxLhrs5ruA=

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "nexpect": "^0.6.0",
         "node-gyp-build": "^4.4.0",
         "nodemon": "^3.0.1",
-        "polykey": "^1.6.1",
+        "polykey": "^1.6.3",
         "prettier": "^3.0.0",
         "shelljs": "^0.8.5",
         "shx": "^0.3.4",
@@ -1541,9 +1541,9 @@
       ]
     },
     "node_modules/@matrixai/quic": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic/-/quic-1.2.7.tgz",
-      "integrity": "sha512-e2RH/xbW4XzoaAKLFgSYmMFW164gVbAFytTYnWtUxS2kY+eJtErFHpvYS1aWfV6LUV2mJLmI7yBfE4IuDUInew==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic/-/quic-1.2.8.tgz",
+      "integrity": "sha512-hGowHtyyu4yaE/L5oy0yOseRllCWX+qi93XKRAbxPgQQXvqEzWk3huGMOGRdf13OdI0ThaTZGAhRT0603oIe3w==",
       "dev": true,
       "dependencies": {
         "@matrixai/async-cancellable": "^1.1.1",
@@ -1558,17 +1558,17 @@
         "ip-num": "^1.5.0"
       },
       "optionalDependencies": {
-        "@matrixai/quic-darwin-arm64": "1.2.7",
-        "@matrixai/quic-darwin-universal": "1.2.7",
-        "@matrixai/quic-darwin-x64": "1.2.7",
-        "@matrixai/quic-linux-x64": "1.2.7",
-        "@matrixai/quic-win32-x64": "1.2.7"
+        "@matrixai/quic-darwin-arm64": "1.2.8",
+        "@matrixai/quic-darwin-universal": "1.2.8",
+        "@matrixai/quic-darwin-x64": "1.2.8",
+        "@matrixai/quic-linux-x64": "1.2.8",
+        "@matrixai/quic-win32-x64": "1.2.8"
       }
     },
     "node_modules/@matrixai/quic-darwin-arm64": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-arm64/-/quic-darwin-arm64-1.2.7.tgz",
-      "integrity": "sha512-X+FmTFUW2TjasNi87AxQfAI+2b2q1BYtJYu8+qqQVaC8htOf3jbgInJ1Msj6thzecQa6v0xgFZ8Oh2Oz9/Kjfg==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-arm64/-/quic-darwin-arm64-1.2.8.tgz",
+      "integrity": "sha512-SkH/Xh3kvKsxc4O/qFSykNz79mtomr5JkM814tuM3vNPeuBMJDeJH517/vuRdlYMOVEx0CWPjlzgNQRfsUepIg==",
       "cpu": [
         "arm64"
       ],
@@ -1579,9 +1579,9 @@
       ]
     },
     "node_modules/@matrixai/quic-darwin-universal": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-universal/-/quic-darwin-universal-1.2.7.tgz",
-      "integrity": "sha512-ljSXCJ7XjBtXI3HzHE9XAMT3na7nruumzS5Si1Y7JpNxWNDNoTa87zwzWEZ4Ws/2dhpE6Ae6epVJ7Xguib9mOw==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-universal/-/quic-darwin-universal-1.2.8.tgz",
+      "integrity": "sha512-nLQKZg3W423NAVhpxus2FskBReu5jn9U21mMwuXyiVLBQcmfnoekIcDoTfpoV7dG6y51dCeiQV+nax5FgI2mqQ==",
       "cpu": [
         "x64",
         "arm64"
@@ -1592,9 +1592,9 @@
       ]
     },
     "node_modules/@matrixai/quic-darwin-x64": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-x64/-/quic-darwin-x64-1.2.7.tgz",
-      "integrity": "sha512-V2gJPkZJOjo55D5VHP9iVIuQdHoGyMX9Xa7P3ur8+gQDSyBklnvgHbp47c3LNEzo8/NcqxRwADp3yzL3Ym94aA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-x64/-/quic-darwin-x64-1.2.8.tgz",
+      "integrity": "sha512-6Mq7cfj4tmYB/hP5G59ooPjZ8w/2k31bbpvIlzemIZ8Atz0rxX2Pj+/AFkBYRCBSgQJKZ+/HxCJCnTOG3Bhe1g==",
       "cpu": [
         "x64"
       ],
@@ -1605,9 +1605,9 @@
       ]
     },
     "node_modules/@matrixai/quic-linux-x64": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-linux-x64/-/quic-linux-x64-1.2.7.tgz",
-      "integrity": "sha512-uRCqCdpQQsHSuYZHfnO+AjWk1fVLZrpJB4tp9bxf6ZA5aPNWSEsbd3Di7ZTeYzw0ONgQBbEI9DW4JjS+WcUIFQ==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-linux-x64/-/quic-linux-x64-1.2.8.tgz",
+      "integrity": "sha512-aQ9MkBxxTsKXoq7XE/OjIFAvjrto7VYGqQs+CV9iRBor5oKN00ePgfxrke9k5vACVMmNU32mCVW0yVsw5q3KuA==",
       "cpu": [
         "x64"
       ],
@@ -1617,9 +1617,9 @@
       ]
     },
     "node_modules/@matrixai/quic-win32-x64": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-win32-x64/-/quic-win32-x64-1.2.7.tgz",
-      "integrity": "sha512-Lzc7JcRyFxXcs4lHXqGFkHZJCs3iBJPeKpuOr3ByC8c3n1KW+kuOeoDH3undbNBTPrZ8/2v5V3fRWPblXk8ZTQ==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-win32-x64/-/quic-win32-x64-1.2.8.tgz",
+      "integrity": "sha512-yjJBco4mKtYMJt1u56VR+lHOuVX1ofMtTEBAwZQ/FGCD7OTMiASzPxuvEguUKcxDXEFpFgNCaJu7Cqv7sktM9Q==",
       "cpu": [
         "x64"
       ],
@@ -7569,9 +7569,9 @@
       }
     },
     "node_modules/polykey": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.6.1.tgz",
-      "integrity": "sha512-HJgedvgIM2aXqAYRU5atbJK5Xs4ZVAA9slXmUlqO3G/eckWweEquD8U/V2wp/1+Lr1d2B5jzaF7/Q6n0WBg3mQ==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.6.3.tgz",
+      "integrity": "sha512-PfjuyMc7QrcyckMUQXCVFstoZgMDDDICTQLRXkYB/EB88N89f7xwxEC2b/A1fpSkYNTnFcGDVvACWiF9KhBKfw==",
       "dev": true,
       "dependencies": {
         "@matrixai/async-cancellable": "^1.1.1",
@@ -7584,7 +7584,7 @@
         "@matrixai/id": "^3.3.6",
         "@matrixai/logger": "^3.1.2",
         "@matrixai/mdns": "^1.2.6",
-        "@matrixai/quic": "^1.2.7",
+        "@matrixai/quic": "^1.2.8",
         "@matrixai/resources": "^1.1.5",
         "@matrixai/rpc": "^0.5.1",
         "@matrixai/timer": "^1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "nexpect": "^0.6.0",
         "node-gyp-build": "^4.4.0",
         "nodemon": "^3.0.1",
-        "polykey": "^1.5.1",
+        "polykey": "^1.6.1",
         "prettier": "^3.0.0",
         "shelljs": "^0.8.5",
         "shx": "^0.3.4",
@@ -7569,9 +7569,9 @@
       }
     },
     "node_modules/polykey": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.5.1.tgz",
-      "integrity": "sha512-CCQLKd2SfxeC0oY3sicQMPrRdWMIqk8mem9ZfCVJhso0QE92NEid2Ac4xqMNX4lB0+R2vvuD5kPgR8UCkJJMfA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.6.1.tgz",
+      "integrity": "sha512-HJgedvgIM2aXqAYRU5atbJK5Xs4ZVAA9slXmUlqO3G/eckWweEquD8U/V2wp/1+Lr1d2B5jzaF7/Q6n0WBg3mQ==",
       "dev": true,
       "dependencies": {
         "@matrixai/async-cancellable": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "nexpect": "^0.6.0",
     "node-gyp-build": "^4.4.0",
     "nodemon": "^3.0.1",
-    "polykey": "^1.6.1",
+    "polykey": "^1.6.3",
     "prettier": "^3.0.0",
     "shelljs": "^0.8.5",
     "shx": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "nexpect": "^0.6.0",
     "node-gyp-build": "^4.4.0",
     "nodemon": "^3.0.1",
-    "polykey": "^1.5.1",
+    "polykey": "^1.6.1",
     "prettier": "^3.0.0",
     "shelljs": "^0.8.5",
     "shx": "^0.3.4",

--- a/src/audit/CommandAudit.ts
+++ b/src/audit/CommandAudit.ts
@@ -1,0 +1,106 @@
+import type PolykeyClient from 'polykey/dist/PolykeyClient';
+import * as binOptions from '../utils/options';
+import * as binProcessors from '../utils/processors';
+import * as binUtils from '../utils';
+import CommandPolykey from '../CommandPolykey';
+
+class CommandIdentities extends CommandPolykey {
+  constructor(...args: ConstructorParameters<typeof CommandPolykey>) {
+    super(...args);
+    this.name('audit');
+    this.description('Displays audit event history');
+    this.addOption(binOptions.nodeId);
+    this.addOption(binOptions.clientHost);
+    this.addOption(binOptions.clientPort);
+    this.addOption(binOptions.seekStart);
+    this.addOption(binOptions.seekEnd);
+    this.addOption(binOptions.follow);
+    this.addOption(binOptions.events);
+    this.addOption(binOptions.limit);
+    this.addOption(binOptions.order);
+    this.action(async (options) => {
+      const { default: PolykeyClient } = await import(
+        'polykey/dist/PolykeyClient'
+      );
+      const auditUtils = await import('polykey/dist/audit/utils');
+      const clientOptions = await binProcessors.processClientOptions(
+        options.nodePath,
+        options.nodeId,
+        options.clientHost,
+        options.clientPort,
+        this.fs,
+        this.logger.getChild(binProcessors.processClientOptions.name),
+      );
+      const auth = await binProcessors.processAuthentication(
+        options.passwordFile,
+        this.fs,
+      );
+      let pkClient: PolykeyClient;
+      this.exitHandlers.handlers.push(async () => {
+        if (pkClient != null) await pkClient.stop();
+      });
+      try {
+        pkClient = await PolykeyClient.createPolykeyClient({
+          nodeId: clientOptions.nodeId,
+          host: clientOptions.clientHost,
+          port: clientOptions.clientPort,
+          options: {
+            nodePath: options.nodePath,
+          },
+          logger: this.logger.getChild(PolykeyClient.name),
+        });
+        // Creating an infinite timer to hold the process open
+        const holdOpenTimer = setTimeout(() => {}, 2 ** 30);
+        // We set up the readable stream watching the discovery events here
+        await binUtils
+          .retryAuthentication(async (auth) => {
+            const seek: number = options.seekStart;
+            const seekEnd: number | undefined = options.seekEnd;
+            const order: 'asc' | 'desc' = options.order;
+            const limit: number | undefined = options.limit;
+            const awaitFutureEvents = options.follow;
+            const readableStream =
+              await pkClient.rpcClient.methods.auditEventsGet({
+                awaitFutureEvents,
+                paths: auditUtils.filterSubPaths(options.events ?? [[]]),
+                seek,
+                seekEnd,
+                order,
+                limit,
+                metadata: auth,
+              });
+            // Tracks vertices that are relevant to our current search
+            for await (const result of readableStream) {
+              const sanitizedResult = {
+                id: result.id,
+                path: result.path.join('.'),
+                data: result.data,
+              };
+              if (options.format === 'json') {
+                process.stdout.write(
+                  binUtils.outputFormatter({
+                    type: 'json',
+                    data: sanitizedResult,
+                  }),
+                );
+              } else {
+                process.stdout.write(
+                  binUtils.outputFormatter({
+                    type: 'dict',
+                    data: { '>': sanitizedResult },
+                  }),
+                );
+              }
+            }
+          }, auth)
+          .finally(() => {
+            clearTimeout(holdOpenTimer);
+          });
+      } finally {
+        if (pkClient! != null) await pkClient.stop();
+      }
+    });
+  }
+}
+
+export default CommandIdentities;

--- a/src/audit/CommandAudit.ts
+++ b/src/audit/CommandAudit.ts
@@ -87,7 +87,7 @@ class CommandIdentities extends CommandPolykey {
                 process.stdout.write(
                   binUtils.outputFormatter({
                     type: 'dict',
-                    data: { '>': sanitizedResult },
+                    data: sanitizedResult,
                   }),
                 );
               }

--- a/src/audit/index.ts
+++ b/src/audit/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CommandAudit';

--- a/src/polykey.ts
+++ b/src/polykey.ts
@@ -142,6 +142,7 @@ async function polykeyMain(argv: Array<string>): Promise<number> {
   const { default: ErrorPolykey } = await import('polykey/dist/ErrorPolykey');
   const { default: CommandBootstrap } = await import('./bootstrap');
   const { default: CommandAgent } = await import('./agent');
+  const { default: CommandAudit } = await import('./audit');
   const { default: CommandVaults } = await import('./vaults');
   const { default: CommandSecrets } = await import('./secrets');
   const { default: CommandKeys } = await import('./keys');
@@ -168,6 +169,7 @@ async function polykeyMain(argv: Array<string>): Promise<number> {
   rootCommand.description('Polykey CLI');
   rootCommand.addCommand(new CommandBootstrap({ exitHandlers, fs }));
   rootCommand.addCommand(new CommandAgent({ exitHandlers, fs }));
+  rootCommand.addCommand(new CommandAudit({ exitHandlers, fs }));
   rootCommand.addCommand(new CommandNodes({ exitHandlers, fs }));
   rootCommand.addCommand(new CommandSecrets({ exitHandlers, fs }));
   rootCommand.addCommand(new CommandKeys({ exitHandlers, fs }));

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -238,6 +238,63 @@ const discoveryMonitor = new commander.Option(
   'Enabling monitoring will cause discover to output discovery events as they happen and will exit once all children are processed',
 ).default(false);
 
+const parseDate = (value: string): number => {
+  if (value.toLowerCase() === 'now') return Date.now();
+  const date = Date.parse(value);
+  if (isNaN(date)) throw Error('Invalid data');
+  return date;
+};
+
+const seekStart = new commander.Option(
+  '--seek-start [seekStart]',
+  `time to start seeking from`,
+)
+  .argParser(parseDate)
+  .default(0);
+
+const seekEnd = new commander.Option(
+  '--seek-end [seekEnd]',
+  `time to seek until`,
+)
+  .argParser(parseDate)
+  .default(undefined);
+
+const follow = new commander.Option(
+  '--follow',
+  'If enabled, future events will be outputted as they happen',
+).default(false);
+
+const events = new commander.Option(
+  '--events [events...]',
+  'Filter for specified event paths',
+)
+  .argParser(
+    (
+      value: string,
+      previous: Array<Array<string>> | undefined,
+    ): Array<Array<string>> => {
+      const parsedPath = value.split('.');
+      const out = previous ?? [];
+      out.push(parsedPath);
+      return out;
+    },
+  )
+  .default(undefined);
+
+const limit = new commander.Option(
+  '--limit [limit]',
+  'Limit the number of emitted events',
+)
+  .argParser(parseInt)
+  .default(undefined);
+
+const order = new commander.Option(
+  '--order [order]',
+  'Filter for specified events',
+)
+  .choices(['asc', 'desc'])
+  .default('asc');
+
 export {
   nodePath,
   format,
@@ -272,4 +329,10 @@ export {
   envInvalid,
   envDuplicate,
   discoveryMonitor,
+  seekStart,
+  seekEnd,
+  follow,
+  events,
+  limit,
+  order,
 };

--- a/tests/audit/audit.test.ts
+++ b/tests/audit/audit.test.ts
@@ -1,0 +1,307 @@
+import type { GestaltIdEncoded } from 'polykey/dist/gestalts/types';
+import path from 'path';
+import fs from 'fs';
+import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
+import PolykeyAgent from 'polykey/dist/PolykeyAgent';
+import * as identitiesUtils from 'polykey/dist/identities/utils';
+import * as keysUtils from 'polykey/dist/keys/utils';
+import * as discoveryEvents from 'polykey/dist/discovery/events';
+import { sleep } from 'polykey/dist/utils';
+import * as testUtils from '../utils';
+
+// @ts-ignore: stub out method
+identitiesUtils.browser = () => {};
+
+describe('audit', () => {
+  const logger = new Logger('audit test', LogLevel.WARN, [new StreamHandler()]);
+  const password = 'password';
+  let dataDir: string;
+  let nodePath: string;
+  let pkAgent: PolykeyAgent;
+  let handleEvent: (evt) => Promise<void>;
+  let processVertex: (
+    parent: string | undefined,
+    children: Array<string>,
+  ) => Promise<void>;
+  beforeEach(async () => {
+    dataDir = await fs.promises.mkdtemp(
+      path.join(globalThis.tmpDir, 'polykey-test-'),
+    );
+    // Set up the remote gestalt state here
+    // Setting up remote nodes
+    nodePath = path.join(dataDir, 'polykey');
+    // Cannot use global shared agent since we need to register a provider
+    pkAgent = await PolykeyAgent.createPolykeyAgent({
+      password,
+      options: {
+        nodePath,
+        agentServiceHost: '127.0.0.1',
+        clientServiceHost: '127.0.0.1',
+        keys: {
+          passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+          passwordMemLimit: keysUtils.passwordMemLimits.min,
+          strictMemoryLock: false,
+        },
+      },
+      logger,
+    });
+
+    const audit = pkAgent.audit;
+    // @ts-ignore: kidnap protected
+    const handlerMap = audit.eventHandlerMap;
+    handleEvent = async (evt) => {
+      await handlerMap.get(evt.constructor)!.handler(evt);
+    };
+    processVertex = async (
+      parent: string | undefined,
+      children: Array<string>,
+    ) => {
+      for (const child of children) {
+        await handleEvent(
+          new discoveryEvents.EventDiscoveryVertexQueued({
+            detail: {
+              vertex: child as GestaltIdEncoded,
+              parent: parent as GestaltIdEncoded,
+            },
+          }),
+        );
+      }
+      if (parent != null) {
+        await handleEvent(
+          new discoveryEvents.EventDiscoveryVertexProcessed({
+            detail: {
+              vertex: parent as GestaltIdEncoded,
+            },
+          }),
+        );
+      }
+    };
+  });
+  afterEach(async () => {
+    await pkAgent.stop();
+    await fs.promises.rm(dataDir, {
+      force: true,
+      recursive: true,
+    });
+  });
+  test('should get all events', async () => {
+    // Start of with mocking some existing discovery events
+    await processVertex(undefined, ['node-A']);
+    await processVertex('node-A', ['node-B', 'node-C']);
+    await processVertex('node-B', ['node-D']);
+    await processVertex('node-C', []);
+    await processVertex('node-D', []);
+    // Checking response
+    const discoverResponse = await testUtils.pkExec(['audit'], {
+      env: {
+        PK_NODE_PATH: nodePath,
+        PK_PASSWORD: password,
+      },
+      cwd: dataDir,
+    });
+    expect(discoverResponse.stdout).toIncludeMultiple([
+      'discovery.vertex.queued',
+      'discovery.vertex.processed',
+      'node-A',
+      'node-B',
+      'node-C',
+      'node-D',
+    ]);
+    expect(discoverResponse.exitCode).toBe(0);
+  });
+  test('should get specific events', async () => {
+    // Start of with mocking some existing discovery events
+    await processVertex(undefined, ['node-A']);
+    await processVertex('node-A', ['node-B', 'node-C']);
+    await processVertex('node-B', ['node-D']);
+    await processVertex('node-C', []);
+    await processVertex('node-D', []);
+    // Checking response
+    const discoverResponse1 = await testUtils.pkExec(
+      ['audit', '--events', 'discovery.vertex.queued'],
+      {
+        env: {
+          PK_NODE_PATH: nodePath,
+          PK_PASSWORD: password,
+        },
+        cwd: dataDir,
+      },
+    );
+    expect(discoverResponse1.stdout).toIncludeMultiple([
+      'discovery.vertex.queued',
+      'node-A',
+      'node-B',
+      'node-C',
+      'node-D',
+    ]);
+    expect(discoverResponse1.stdout).not.toInclude('processed');
+    expect(discoverResponse1.exitCode).toBe(0);
+
+    const discoverResponse2 = await testUtils.pkExec(
+      ['audit', '--events', 'discovery.vertex.processed'],
+      {
+        env: {
+          PK_NODE_PATH: nodePath,
+          PK_PASSWORD: password,
+        },
+        cwd: dataDir,
+      },
+    );
+    expect(discoverResponse2.stdout).toIncludeMultiple([
+      'discovery.vertex.processed',
+      'node-A',
+      'node-B',
+      'node-C',
+      'node-D',
+    ]);
+    expect(discoverResponse2.stdout).not.toInclude('discovery.vertex.queued');
+    expect(discoverResponse2.exitCode).toBe(0);
+
+    const discoverResponse3 = await testUtils.pkExec(
+      [
+        'audit',
+        '--events',
+        'discovery.vertex.processed',
+        'discovery.vertex.queued',
+      ],
+      {
+        env: {
+          PK_NODE_PATH: nodePath,
+          PK_PASSWORD: password,
+        },
+        cwd: dataDir,
+      },
+    );
+    expect(discoverResponse3.stdout).toIncludeMultiple([
+      'discovery.vertex.processed',
+      'discovery.vertex.queued',
+      'node-A',
+      'node-B',
+      'node-C',
+      'node-D',
+    ]);
+    expect(discoverResponse3.exitCode).toBe(0);
+  });
+  test('should seek from seekStart', async () => {
+    // Start of with mocking some existing discovery events
+    await processVertex('node-A', ['node-AA']);
+    await processVertex('node-B', ['node-BA']);
+    await processVertex('node-C', ['node-CA']);
+    await sleep(50);
+    const date = new Date();
+    await sleep(50);
+    await processVertex('node-E', ['node-EA']);
+    await processVertex('node-F', ['node-FA']);
+    await processVertex('node-G', ['node-GA']);
+    // Checking response
+    const discoverResponse1 = await testUtils.pkExec(
+      ['audit', '--seek-start', date.toISOString()],
+      {
+        env: {
+          PK_NODE_PATH: nodePath,
+          PK_PASSWORD: password,
+        },
+        cwd: dataDir,
+      },
+    );
+    expect(discoverResponse1.stdout).not.toInclude('node-A');
+    expect(discoverResponse1.stdout).not.toInclude('node-AA');
+    expect(discoverResponse1.stdout).not.toInclude('node-B');
+    expect(discoverResponse1.stdout).not.toInclude('node-BA');
+    expect(discoverResponse1.stdout).not.toInclude('node-C');
+    expect(discoverResponse1.stdout).not.toInclude('node-CA');
+    expect(discoverResponse1.stdout).toIncludeMultiple([
+      'queued',
+      'processed',
+      'node-E',
+      'node-EA',
+      'node-F',
+      'node-FA',
+      'node-G',
+      'node-GA',
+    ]);
+    expect(discoverResponse1.exitCode).toBe(0);
+  });
+  test('should seek until seekEnd', async () => {
+    // Start of with mocking some existing discovery events
+    await processVertex('node-A', ['node-AA']);
+    await processVertex('node-B', ['node-BA']);
+    await processVertex('node-C', ['node-CA']);
+    await sleep(50);
+    const date = new Date();
+    await sleep(50);
+    await processVertex('node-E', ['node-EA']);
+    await processVertex('node-F', ['node-FA']);
+    await processVertex('node-G', ['node-GA']);
+    // Checking response
+    const discoverResponse1 = await testUtils.pkExec(
+      ['audit', '--seek-end', date.toISOString()],
+      {
+        env: {
+          PK_NODE_PATH: nodePath,
+          PK_PASSWORD: password,
+        },
+        cwd: dataDir,
+      },
+    );
+    expect(discoverResponse1.stdout).toIncludeMultiple([
+      'queued',
+      'processed',
+      'node-A',
+      'node-AA',
+      'node-B',
+      'node-BA',
+      'node-C',
+      'node-CA',
+    ]);
+    expect(discoverResponse1.stdout).not.toInclude('node-E');
+    expect(discoverResponse1.stdout).not.toInclude('node-EA');
+    expect(discoverResponse1.stdout).not.toInclude('node-F');
+    expect(discoverResponse1.stdout).not.toInclude('node-FA');
+    expect(discoverResponse1.stdout).not.toInclude('node-G');
+    expect(discoverResponse1.stdout).not.toInclude('node-GA');
+    expect(discoverResponse1.exitCode).toBe(0);
+  });
+  test('should seek until limit', async () => {
+    // Start of with mocking some existing discovery events
+    await processVertex(undefined, ['node-A']);
+    await processVertex(undefined, ['node-A']);
+    await processVertex(undefined, ['node-A']);
+    await processVertex(undefined, ['node-A']);
+    // Checking response
+    const discoverResponse = await testUtils.pkExec(['audit', '--limit', '2'], {
+      env: {
+        PK_NODE_PATH: nodePath,
+        PK_PASSWORD: password,
+      },
+      cwd: dataDir,
+    });
+    expect(discoverResponse.stdout).toIncludeRepeated('queued', 2);
+    expect(discoverResponse.stdout).toIncludeRepeated('node-A', 2);
+    expect(discoverResponse.exitCode).toBe(0);
+  });
+  test('should await future events', async () => {
+    // Start of with mocking some existing discovery events
+    await processVertex('node-A', ['node-AA']);
+    await processVertex('node-B', ['node-BA']);
+    await processVertex('node-C', ['node-CA']);
+    await sleep(100);
+    const discoverResponseP = testUtils.pkExec(
+      ['audit', '--follow', '--limit', '12'],
+      {
+        env: {
+          PK_NODE_PATH: nodePath,
+          PK_PASSWORD: password,
+        },
+        cwd: dataDir,
+      },
+    );
+    await sleep(100);
+    await processVertex('node-E', ['node-EA']);
+    await processVertex('node-F', ['node-FA']);
+    await processVertex('node-G', ['node-GA']);
+    // Checking response
+    const discoverResponse = await discoverResponseP;
+    expect(discoverResponse.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Description

This PR addresses adding the Audit domain to the CLI.

I have some work in progress done, but it needs to be made more generic. The specific `audit discovery` command needs to be generalised to a `audit` command that handles all audit events.

We may need to add formatters for specific event types. For example the discovery events have verticies as the `GestaltIdEncoded`. It may be fine to output that as is. But ideally we'd keep gestaltId formatting consistent, so a node would be   `NodeIdEncoded` and identitiy as `identitiyId:providerId`.

### Issues Fixed

* Fixes #177 

### Tasks

- [x] 1. Create a generic `polykey audit` command.
- [x] 2. Support providing multiple event paths in a dot path format `a.b.c`.
- [x] 3. Create tests checking functionality.

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
