### PR TITLE
fix:read spaces in secretPath

### DIFF
--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -63,9 +63,10 @@ function parseCoreCount(v: string): number | undefined {
 
 function parseSecretPath(secretPath: string): [string, string, string?] {
   // E.g. If 'vault1:a/b/c', ['vault1', 'a/b/c'] is returned
-  //      If 'vault1:a/b/c=VARIABLE', ['vault1, 'a/b/c', 'VARIABLE'] is returned
+  //      If 'vault1:a/b/c=VARIABLE', ['vault1', 'a/b/c', 'VARIABLE'] is returned
+  //      If 'vault1:my dir/my other dir', ['vault1', 'my dir/my other dir'] is returned
   const secretPathRegex =
-    /^([\w-]+)(?::)([\w\-\\\/\.\$]+)(?:=)?([a-zA-Z_][\w]+)?$/;
+    /^([\w-]+)(?::)([\w\-\\\/\.\$ ]+)(?:=)?([a-zA-Z_][\w]+)?$/;
   if (!secretPathRegex.test(secretPath)) {
     throw new commander.InvalidArgumentError(
       `${secretPath} is not of the format <vaultName>:<directoryPath>`,


### PR DESCRIPTION
### Description
When creating a secret, secretPaths should be able to handle spaces and not throw an error.
![Screenshot_20240614_105733](https://github.com/MatrixAI/Polykey-CLI/assets/108529942/9dc6713e-242c-48d4-a4b6-1d356f996ed2)

### Issues Fixed

* Fixes #199 
* REF ENG-335

### Tasks

- [x] 1. Support spaces within secret paths.
- [x] 2. Added tests testing this functionality.

### Final checklist
* [ ] Domain specific tests
* [ ] Full tests
* [ ] Updated inline-comment documentation
* [ ] Lint fixed
* [ ] Squash and rebased
* [ ] Sanity check the final build
