### PR TITLE
Adding newline spacing between entries on list outputs

### DIFF
--- a/src/identities/CommandAuthenticated.ts
+++ b/src/identities/CommandAuthenticated.ts
@@ -54,11 +54,15 @@ class CommandAuthenticated extends CommandPolykey {
               metadata: auth,
               providerId: options.providerId,
             });
+          let head = true;
           for await (const identityMessage of readableStream) {
             const output = {
               providerId: identityMessage.providerId,
               identityId: identityMessage.identityId,
             };
+            // Add a new line between entries
+            if (!head) process.stdout.write('\n');
+            head = false;
             process.stdout.write(
               binUtils.outputFormatter({
                 type: options.format === 'json' ? 'json' : 'dict',

--- a/src/identities/CommandList.ts
+++ b/src/identities/CommandList.ts
@@ -85,6 +85,7 @@ class CommandList extends CommandPolykey {
             }),
           );
         } else {
+          let head = true;
           // Convert to a human-readable list.
           for (const gestaltMessage of gestaltMessages) {
             const gestalt = gestaltMessage.gestalt;
@@ -94,6 +95,8 @@ class CommandList extends CommandPolykey {
             const identities = Object.values(gestalt.identities).map(
               (identity) => `${identity.providerId}:${identity.identityId}`,
             );
+            if (!head) process.stdout.write('\n');
+            head = false;
             process.stdout.write(
               binUtils.outputFormatter({
                 type: 'dict',

--- a/src/identities/CommandQueue.ts
+++ b/src/identities/CommandQueue.ts
@@ -47,6 +47,7 @@ class CommandQueue extends CommandPolykey {
             await pkClient.rpcClient.methods.gestaltsDiscoveryQueue({
               metadata: auth,
             });
+          let head = true;
           for await (const discoveryQueueInfo of readableStream) {
             const sanitizedData = {
               id: discoveryQueueInfo.id,
@@ -66,6 +67,8 @@ class CommandQueue extends CommandPolykey {
                 }),
               );
             } else {
+              if (!head) process.stdout.write('\n');
+              head = false;
               process.stdout.write(
                 binUtils.outputFormatter({
                   type: 'dict',

--- a/src/identities/CommandSearch.ts
+++ b/src/identities/CommandSearch.ts
@@ -125,7 +125,10 @@ class CommandSearch extends CommandPolykey {
               );
             }
           } else {
+            let head = true;
             for await (const output of readableStream) {
+              if (!head) process.stdout.write('\n');
+              head = false;
               process.stdout.write(
                 binUtils.outputFormatter({
                   type: 'dict',

--- a/src/notifications/inbox/CommandRead.ts
+++ b/src/notifications/inbox/CommandRead.ts
@@ -93,7 +93,10 @@ class CommandRead extends CommandPolykey {
             }),
           );
         } else {
+          let head = true;
           for (const notificationReadMessage of notificationReadMessages) {
+            if (!head) process.stdout.write('\n');
+            head = false;
             process.stdout.write(
               binUtils.outputFormatter({
                 type: 'dict',

--- a/src/notifications/outbox/CommandRead.ts
+++ b/src/notifications/outbox/CommandRead.ts
@@ -93,12 +93,15 @@ class CommandRead extends CommandPolykey {
             }),
           );
         } else {
+          let head = true;
           for (const notificationReadMessage of notificationReadMessages) {
+            if (!head) process.stdout.write('\n');
+            head = false;
             process.stdout.write(
               binUtils.outputFormatter({
                 type: 'dict',
                 data: {
-                  notificiation: notificationReadMessage.notification,
+                  notification: notificationReadMessage.notification,
                   taskMetadata: notificationReadMessage.taskMetadata,
                 },
               }),

--- a/src/vaults/CommandLog.ts
+++ b/src/vaults/CommandLog.ts
@@ -75,7 +75,10 @@ class CommandLog extends CommandPolykey {
             binUtils.outputFormatter({ type: 'json', data }),
           );
         } else {
+          let head = true;
           for (const entry of data) {
+            if (!head) process.stdout.write('\n');
+            head = false;
             process.stdout.write(
               binUtils.outputFormatter({ type: 'dict', data: entry }),
             );

--- a/src/vaults/CommandPermissions.ts
+++ b/src/vaults/CommandPermissions.ts
@@ -77,9 +77,12 @@ class CommandPermissions extends CommandPolykey {
             }),
           );
         } else {
+          let head = true;
           for (const permission of data) {
             permission.vaultPermissionList =
               permission.vaultPermissionList.join(',') as any;
+            if (!head) process.stdout.write('\n');
+            head = false;
             process.stdout.write(
               binUtils.outputFormatter({
                 type: 'dict',


### PR DESCRIPTION
### Description

 Currently when we have a command that returns a list of output. Usually in the `dict` format for human readability. the output has no clear separation between entries. This PR addresses this by adding newline spacing between the entries.

### Issues Fixed

* Fixes #200 

### Tasks

- [x] 1. Modify any command that outputs a list to include a newline space between entries where needed.
- [x] 2. Check that all tests are passing after the changes.

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
