### PR TITLE
Add support for unix style paths for secret paths

### DIFF
--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -8,10 +8,9 @@ import * as gestaltsUtils from 'polykey/dist/gestalts/utils';
 import * as networkUtils from 'polykey/dist/network/utils';
 import * as nodesUtils from 'polykey/dist/nodes/utils';
 
-const secretPathRegex =
-  /^([\w-]+)(?::)([\w\-\\\/\.\$]+)(?:=)?([a-zA-Z_][\w]+)?$/;
+const secretPathRegex = /^([\w-]+)(?::)([^\0\\=]+)(?:=)?([a-zA-Z_][\w]+)?$/;
 const secretPathEnvRegex =
-  /^([\w-]+)(?::)([\w\-\\\/\.\$]+)(?:=)?([a-zA-Z_]+[a-zA-Z0-9_]*)?$/;
+  /^([\w-]+)(?::)([^\0\\=]+)(?:=)?([a-zA-Z_]+[a-zA-Z0-9_]*)?$/;
 
 /**
  * Converts a validation parser to commander argument parser


### PR DESCRIPTION
### Description

This PR addresses allowing spaces and other valid characters within the secret paths.

### Issues Fixed

* Fixes #199 
* REF ENG-335

### Tasks

- [X] 1. Update the parser to allow for all valid file paths
- [X] 2. Add a fast-check test for testing this.

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
