### PR TITLE
feat: adding `--dns-servers` option to `agent start` command

### DIFF
--- a/npmDepsHash
+++ b/npmDepsHash
@@ -1,1 +1,1 @@
-sha256-eDUzTAx7aYrCZinucP9pNHaayK66WNiPz3vOs9H5xNI=
+sha256-zFQzJUqz3y5Z8EUyeEycGSttQ+VHlPjJwhgDQA35ul0=

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "nexpect": "^0.6.0",
         "node-gyp-build": "^4.4.0",
         "nodemon": "^3.0.1",
-        "polykey": "^1.6.4",
+        "polykey": "^1.7.4",
         "prettier": "^3.0.0",
         "shelljs": "^0.8.5",
         "shx": "^0.3.4",
@@ -7602,9 +7602,9 @@
       }
     },
     "node_modules/polykey": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.6.4.tgz",
-      "integrity": "sha512-88nzPEkzYOssJlYfMZUlSonRpbpbkCQFciPu/gBa8++RAsyDTPMKkFjtED4m8KCB+EeZ/QBVd7UCZ+THlcw0cg==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.7.4.tgz",
+      "integrity": "sha512-evhqFBMVJQCgHZGuX48ELsy/u0qqn1ye/xMwSJZB7za8Bw8xetvuEdsCO4JzJniRHHPThBgYko5FFZSs605dUA==",
       "dev": true,
       "dependencies": {
         "@matrixai/async-cancellable": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "nexpect": "^0.6.0",
     "node-gyp-build": "^4.4.0",
     "nodemon": "^3.0.1",
-    "polykey": "^1.6.4",
+    "polykey": "^1.7.4",
     "prettier": "^3.0.0",
     "shelljs": "^0.8.5",
     "shx": "^0.3.4",

--- a/src/agent/CommandStart.ts
+++ b/src/agent/CommandStart.ts
@@ -128,7 +128,8 @@ class CommandStart extends CommandPolykey {
             keysUtils.passwordMemLimits[options.passwordMemLimit],
         },
         nodes: {
-          dnsServers: options.dnsServers,
+          // `--dns-server` with no value returns true, convert that to an empty list
+          dnsServers: options.dnsServers === true ? [] : options.dnsServers,
         },
         versionMetadata: buildJSON.versionMetadata,
       };

--- a/src/agent/CommandStart.ts
+++ b/src/agent/CommandStart.ts
@@ -45,6 +45,7 @@ class CommandStart extends CommandPolykey {
     this.addOption(binOptions.privateKeyFile);
     this.addOption(binOptions.passwordOpsLimit);
     this.addOption(binOptions.passwordMemLimit);
+    this.addOption(binOptions.dnsServers);
     this.action(async (options) => {
       options.clientHost =
         options.clientHost ?? config.defaultsUser.clientServiceHost;
@@ -125,6 +126,9 @@ class CommandStart extends CommandPolykey {
             keysUtils.passwordOpsLimits[options.passwordOpsLimit],
           passwordMemLimit:
             keysUtils.passwordMemLimits[options.passwordMemLimit],
+        },
+        nodes: {
+          dnsServers: options.dnsServers,
         },
         versionMetadata: buildJSON.versionMetadata,
       };

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -83,6 +83,14 @@ const agentPort = new commander.Option('-ap, --agent-port <port>', 'Agent Port')
   .argParser(binParsers.parsePort)
   .default(config.defaultsUser.agentServicePort);
 
+const dnsServers = new commander.Option(
+  '--dns-servers [addresses...]',
+  'List of dns servers used for dns resolution',
+)
+  .env('PK_DNS_SERVERS')
+  .argParser(binParsers.parseAddresses)
+  .default(undefined);
+
 const connConnectTime = new commander.Option(
   '--connection-timeout <ms>',
   'Timeout value for connection establishment between nodes',
@@ -304,6 +312,7 @@ export {
   clientPort,
   agentHost,
   agentPort,
+  dnsServers,
   connConnectTime,
   recoveryCodeFile,
   recoveryCodeOutFile,

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -147,6 +147,15 @@ const parseHostname: (data: string) => Hostname = validateParserToArgParser(
 const parseHostOrHostname: (data: string) => Host | Hostname =
   validateParserToArgParser(networkUtils.parseHostOrHostname);
 
+function parseAddresses(
+  value: string,
+  previous: Array<string> | undefined,
+): Array<string> {
+  const current = previous ?? [];
+  current.push(parseHostOrHostname(value));
+  return current;
+}
+
 const parsePort: (data: string) => Port = validateParserToArgParser(
   networkUtils.parsePort,
 );
@@ -208,6 +217,7 @@ export {
   parseHost,
   parseHostname,
   parseHostOrHostname,
+  parseAddresses,
   parsePort,
   parseSeedNodes,
   parseProviderId,


### PR DESCRIPTION
### Description

This PR adds a `--dns-servers` option for `agent start` command. This allows the user to provide a list of dns servers to do lookups against when needed. If this is not provided it will default to using the OS configured servers in stead.

### Issues Fixed

* Fixes #202 
* REF ENG-338

### Tasks

- [X] 1. Create parser for a variable length set of addresses
- [X] 2. Create an `--dns-servers` option.
- [x] 3. Update `polykey` dependency version to support the new option.

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
