### PR TITLE
Implementing UNIX-like `secrets ls` command

### DIFF
--- a/npmDepsHash
+++ b/npmDepsHash
@@ -1,1 +1,1 @@
-sha256-NF/FIaXGr8EAxGRp+e9KP9+Vcb3KFzJBir/bZqU0J+w=
+sha256-N6qZhhoqgktogCaRmQO1/9dFbSL9SISI5y/37kjD95U=

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "polykey-cli",
-  "version": "0.6.5",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "polykey-cli",
-      "version": "0.6.5",
+      "version": "0.6.3",
       "license": "GPL-3.0",
       "bin": {
         "pk": "dist/polykey.js",
@@ -42,7 +42,7 @@
         "nexpect": "^0.6.0",
         "node-gyp-build": "^4.4.0",
         "nodemon": "^3.0.1",
-        "polykey": "^1.9.0",
+        "polykey": "^1.10.0",
         "prettier": "^3.0.0",
         "shelljs": "^0.8.5",
         "shx": "^0.3.4",
@@ -7602,9 +7602,9 @@
       }
     },
     "node_modules/polykey": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.9.0.tgz",
-      "integrity": "sha512-ijdunJR66xylrA2g408zItwPKNEh5wiofk9Fj1q8QRuV1ZHsrVl1q+4/mxQXvpDmAq7fOH3YppwvD52oZd9o+w==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/polykey/-/polykey-1.10.0.tgz",
+      "integrity": "sha512-An0lrW2KK+zO0J1Ig7j5cZ7ZwaEc1XGdsCNx0bx8a7UxusBc+A76WtdLuEhH27yiVNfBVgruMny+4htTE8uDiw==",
       "dev": true,
       "dependencies": {
         "@matrixai/async-cancellable": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polykey-cli",
-  "version": "0.6.5",
+  "version": "0.6.3",
   "homepage": "https://polykey.com",
   "author": "Roger Qiu",
   "contributors": [
@@ -150,7 +150,7 @@
     "nexpect": "^0.6.0",
     "node-gyp-build": "^4.4.0",
     "nodemon": "^3.0.1",
-    "polykey": "^1.9.0",
+    "polykey": "^1.10.0",
     "prettier": "^3.0.0",
     "shelljs": "^0.8.5",
     "shx": "^0.3.4",

--- a/src/secrets/CommandList.ts
+++ b/src/secrets/CommandList.ts
@@ -14,7 +14,7 @@ class CommandList extends CommandPolykey {
     this.argument(
       '<directoryPath>',
       'Directory to list files from, specified as <vaultName>[:<path>]',
-      binParsers.parseSecretName,
+      binParsers.parseSecretPathOptional,
     );
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);

--- a/src/secrets/CommandList.ts
+++ b/src/secrets/CommandList.ts
@@ -3,18 +3,23 @@ import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
 import * as binProcessors from '../utils/processors';
+import * as binParsers from '../utils/parsers';
 
 class CommandList extends CommandPolykey {
   constructor(...args: ConstructorParameters<typeof CommandPolykey>) {
     super(...args);
-    this.name('list');
-    this.aliases(['ls']);
-    this.description('List all Available Secrets for a Vault');
-    this.argument('<vaultName>', 'Name of the vault to list secrets from');
+    this.name('ls');
+    this.aliases(['list']);
+    this.description('List all secrets for a vault within a directory');
+    this.argument(
+      '<directoryPath>',
+      'Directory to list files from, specified as <vaultName>[:<path>]',
+      binParsers.parseSecretName,
+    );
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
-    this.action(async (vaultName, options) => {
+    this.action(async (vaultPattern, options) => {
       const { default: PolykeyClient } = await import(
         'polykey/dist/PolykeyClient'
       );
@@ -40,39 +45,38 @@ class CommandList extends CommandPolykey {
           nodeId: clientOptions.nodeId,
           host: clientOptions.clientHost,
           port: clientOptions.clientPort,
-          options: {
-            nodePath: options.nodePath,
-          },
+          options: { nodePath: options.nodePath },
           logger: this.logger.getChild(PolykeyClient.name),
         });
-        const data = await binUtils.retryAuthentication(async (auth) => {
-          const data: Array<{ secretName: string }> = [];
+        const secretPaths = await binUtils.retryAuthentication(async (auth) => {
+          const secretPaths: Array<string> = [];
           const stream = await pkClient.rpcClient.methods.vaultsSecretsList({
             metadata: auth,
-            nameOrId: vaultName,
+            nameOrId: vaultPattern[0],
+            secretName: vaultPattern[1] ?? '/',
           });
           for await (const secret of stream) {
-            data.push({
-              secretName: secret.secretName,
-            });
+            // Remove leading slashes
+            if (secret.path.startsWith('/')) {
+              secret.path = secret.path.substring(1);
+            }
+            secretPaths.push(secret.path);
           }
-          return data;
+          return secretPaths;
         }, auth);
 
         if (options.format === 'json') {
           process.stdout.write(
             binUtils.outputFormatter({
               type: 'json',
-              data: data,
+              data: secretPaths,
             }),
           );
         } else {
           process.stdout.write(
             binUtils.outputFormatter({
               type: 'list',
-              data: data.map(
-                (secretsListMessage) => secretsListMessage.secretName,
-              ),
+              data: secretPaths,
             }),
           );
         }

--- a/src/secrets/CommandSecrets.ts
+++ b/src/secrets/CommandSecrets.ts
@@ -8,7 +8,7 @@ import CommandList from './CommandList';
 import CommandMkdir from './CommandMkdir';
 import CommandRename from './CommandRename';
 import CommandUpdate from './CommandUpdate';
-import commandStat from './CommandStat';
+import CommandStat from './CommandStat';
 import CommandPolykey from '../CommandPolykey';
 
 class CommandSecrets extends CommandPolykey {
@@ -26,7 +26,7 @@ class CommandSecrets extends CommandPolykey {
     this.addCommand(new CommandMkdir(...args));
     this.addCommand(new CommandRename(...args));
     this.addCommand(new CommandUpdate(...args));
-    this.addCommand(new commandStat(...args));
+    this.addCommand(new CommandStat(...args));
   }
 }
 

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -8,8 +8,7 @@ import * as gestaltsUtils from 'polykey/dist/gestalts/utils';
 import * as networkUtils from 'polykey/dist/network/utils';
 import * as nodesUtils from 'polykey/dist/nodes/utils';
 
-const vaultNameRegex = /^[\w.-]+$/;
-const secretPathNameRegex = /^([\w-]+)(?::([^\0\\=]+))?$/;
+const secretPathRegex = /^([\w-]+)(?::([^\0\\=]+))?$/;
 const secretPathValueRegex = /^([a-zA-Z_][\w]+)?$/;
 const environmentVariableRegex = /^([a-zA-Z_]+[a-zA-Z0-9_]*)?$/;
 
@@ -66,47 +65,44 @@ function parseCoreCount(v: string): number | undefined {
   }
 }
 
-function parseVaultName(vaultName: string): string {
-  // E.g. If 'vault1, 'vault1' is returned
-  //      If 'vault1:a/b/c', an error is thrown
-  if (!vaultNameRegex.test(vaultName)) {
-    throw new commander.InvalidArgumentError(
-      `${vaultName} is not of the format <vaultName>`,
-    );
-  }
-  // Returns match[1], or the parsed vaultName
-  return vaultName.match(secretPathNameRegex)![1];
-}
-
-function parseSecretName(secretPath: string): [string, string?] {
+function parseSecretPathOptional(
+  secretPath: string,
+): [string, string?, string?] {
   // E.g. If 'vault1:a/b/c', ['vault1', 'a/b/c'] is returned
   //      If 'vault1', ['vault1, undefined] is returned
-  if (!secretPathNameRegex.test(secretPath)) {
+  // splits out everything after an `=` separator
+  const lastEqualIndex = secretPath.lastIndexOf('=');
+  const splitSecretPath =
+    lastEqualIndex === -1
+      ? secretPath
+      : secretPath.substring(0, lastEqualIndex);
+  const value =
+    lastEqualIndex === -1
+      ? undefined
+      : secretPath.substring(lastEqualIndex + 1);
+  if (!secretPathRegex.test(splitSecretPath)) {
     throw new commander.InvalidArgumentError(
-      `${secretPath} is not of the format <vaultName>[:<directoryPath>]`,
+      `${secretPath} is not of the format <vaultName>[:<directoryPath>][=<value>]`,
     );
   }
-  // Returns [vaultName, secretName?]
-  const match = secretPath.match(secretPathNameRegex)!;
-  return [match[1], match[2] || undefined];
+  const [, vaultName, directoryPath] = splitSecretPath.match(secretPathRegex)!;
+  return [vaultName, directoryPath, value];
 }
 
 function parseSecretPath(secretPath: string): [string, string, string?] {
   // E.g. If 'vault1:a/b/c', ['vault1', 'a/b/c'] is returned
   //      If 'vault1', an error is thrown
-  const [vaultName, secretName] = parseSecretName(secretPath);
+  const [vaultName, secretName, value] = parseSecretPathOptional(secretPath);
   if (secretName === undefined) {
     throw new commander.InvalidArgumentError(
-      `${secretPath} is not of the format <vaultName>:<directoryPath>`,
+      `${secretPath} is not of the format <vaultName>:<directoryPath>[=<value>]`,
     );
   }
-  return [vaultName, secretName];
+  return [vaultName, secretName, value];
 }
 
 function parseSecretPathValue(secretPath: string): [string, string, string?] {
-  const [vaultName, directoryPath] = parseSecretPath(secretPath);
-  const lastEqualIndex = secretPath.lastIndexOf('=');
-  const value = lastEqualIndex === -1 ? '' : secretPath.substring(lastEqualIndex + 1);
+  const [vaultName, directoryPath, value] = parseSecretPath(secretPath);
   if (value != null && !secretPathValueRegex.test(value)) {
     throw new commander.InvalidArgumentError(
       `${value} is not a valid value name`,
@@ -219,13 +215,13 @@ function parseEnvArgs(
 }
 
 export {
+  secretPathRegex,
   secretPathValueRegex,
   environmentVariableRegex,
   validateParserToArgParser,
   validateParserToArgListParser,
   parseCoreCount,
-  parseVaultName,
-  parseSecretName,
+  parseSecretPathOptional,
   parseSecretPath,
   parseSecretPathValue,
   parseSecretPathEnv,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -254,7 +254,7 @@ function outputFormatterList(items: Array<string>): string {
  * If it is `Record<string, number>`, the `number` values will be used as the initial padding lengths.
  * The object is also mutated if any cells exceed the initial padding lengths.
  * This parameter can also be supplied to filter the columns that will be displayed.
- * @param options.includeHeaders - Defaults to `True`
+ * @param options.includeHeaders - Defaults to `True`.
  * @param options.includeRowCount - Defaults to `False`.
  * @returns
  */

--- a/src/vaults/CommandCreate.ts
+++ b/src/vaults/CommandCreate.ts
@@ -4,6 +4,7 @@ import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
 import * as binProcessors from '../utils/processors';
+import * as binParsers from '../utils/parsers';
 
 class CommandCreate extends CommandPolykey {
   constructor(...args: ConstructorParameters<typeof CommandPolykey>) {
@@ -11,7 +12,11 @@ class CommandCreate extends CommandPolykey {
     this.name('create');
     this.aliases(['touch']);
     this.description('Create a new Vault');
-    this.argument('<vaultName>', 'Name of the new vault to be created');
+    this.argument(
+      '<vaultName>',
+      'Name of the new vault to be created',
+      binParsers.parseVaultName,
+    );
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);

--- a/src/vaults/CommandCreate.ts
+++ b/src/vaults/CommandCreate.ts
@@ -4,7 +4,6 @@ import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
 import * as binProcessors from '../utils/processors';
-import * as binParsers from '../utils/parsers';
 
 class CommandCreate extends CommandPolykey {
   constructor(...args: ConstructorParameters<typeof CommandPolykey>) {
@@ -12,11 +11,7 @@ class CommandCreate extends CommandPolykey {
     this.name('create');
     this.aliases(['touch']);
     this.description('Create a new Vault');
-    this.argument(
-      '<vaultName>',
-      'Name of the new vault to be created',
-      binParsers.parseVaultName,
-    );
+    this.argument('<vaultName>', 'Name of the new vault to be created');
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);

--- a/tests/secrets/env.test.ts
+++ b/tests/secrets/env.test.ts
@@ -764,7 +764,7 @@ describe('commandEnv', () => {
     const jsonOut = JSON.parse(result.stdout);
     expect(jsonOut['SECRET']).toBe('this is a secret\nit has multiple lines\n');
   });
-  test.only.prop([
+  test.prop([
     testUtils.secretPathEnvArrayArb,
     fc.string().noShrink(),
     testUtils.cmdArgsArrayArb,
@@ -773,7 +773,6 @@ describe('commandEnv', () => {
     async (secretPathEnvArray, cmd, cmdArgsArray) => {
       // If we don't use the optional `--` delimiter then we can't include `:` in vault names
       fc.pre(!cmd.includes(':'));
-
       let output:
         | [Array<[string, string, string?]>, Array<string>]
         | undefined = undefined;

--- a/tests/secrets/list.test.ts
+++ b/tests/secrets/list.test.ts
@@ -42,19 +42,33 @@ describe('commandListSecrets', () => {
   });
 
   test(
+    'should fail when vault does not exist',
+    async () => {
+      command = ['secrets', 'ls', '-np', dataDir, 'DoesntExist'];
+      const result = await testUtils.pkStdio([...command], {
+        env: {
+          PK_PASSWORD: password,
+        },
+        cwd: dataDir,
+      });
+      expect(result.exitCode).toBe(64); // Sysexits.USAGE
+    },
+    globalThis.defaultTimeout * 2,
+  );
+
+  test(
     'should list secrets',
     async () => {
       const vaultName = 'Vault4' as VaultName;
       const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
 
       await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
-        await vaultOps.addSecret(vault, 'MySecret1', 'this is the secret 1');
-        await vaultOps.addSecret(vault, 'MySecret2', 'this is the secret 2');
-        await vaultOps.addSecret(vault, 'MySecret3', 'this is the secret 3');
+        await vaultOps.addSecret(vault, 'MySecret1', '');
+        await vaultOps.addSecret(vault, 'MySecret2', '');
+        await vaultOps.addSecret(vault, 'MySecret3', '');
       });
 
-      command = ['secrets', 'list', '-np', dataDir, vaultName];
-
+      command = ['secrets', 'ls', '-np', dataDir, vaultName];
       const result = await testUtils.pkStdio([...command], {
         env: {
           PK_PASSWORD: password,
@@ -62,6 +76,88 @@ describe('commandListSecrets', () => {
         cwd: dataDir,
       });
       expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('MySecret1\nMySecret2\nMySecret3\n');
+    },
+    globalThis.defaultTimeout * 2,
+  );
+
+  test(
+    'should fail when path is not a directory',
+    async () => {
+      const vaultName = 'Vault5' as VaultName;
+      const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
+
+      await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
+        await vaultOps.mkdir(vault, 'SecretDir');
+        await vaultOps.addSecret(vault, 'SecretDir/MySecret1', '');
+        await vaultOps.addSecret(vault, 'SecretDir/MySecret2', '');
+        await vaultOps.addSecret(vault, 'SecretDir/MySecret3', '');
+      });
+
+      command = ['secrets', 'ls', '-np', dataDir, `${vaultName}:WrongDirName`];
+      let result = await testUtils.pkStdio([...command], {
+        env: {
+          PK_PASSWORD: password,
+        },
+        cwd: dataDir,
+      });
+      expect(result.exitCode).toBe(64);
+
+      command = [
+        'secrets',
+        'ls',
+        '-np',
+        dataDir,
+        `${vaultName}:SecretDir/MySecret1`,
+      ];
+      result = await testUtils.pkStdio([...command], {
+        env: {
+          PK_PASSWORD: password,
+        },
+        cwd: dataDir,
+      });
+      expect(result.exitCode).toBe(64);
+    },
+    globalThis.defaultTimeout * 2,
+  );
+
+  test(
+    'should list secrets within directories',
+    async () => {
+      const vaultName = 'Vault6' as VaultName;
+      const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
+
+      await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
+        await vaultOps.mkdir(vault, 'SecretDir/NestedDir', { recursive: true });
+        await vaultOps.addSecret(vault, 'SecretDir/MySecret1', '');
+        await vaultOps.addSecret(vault, 'SecretDir/NestedDir/MySecret2', '');
+      });
+
+      command = ['secrets', 'ls', '-np', dataDir, `${vaultName}:SecretDir`];
+      let result = await testUtils.pkStdio([...command], {
+        env: {
+          PK_PASSWORD: password,
+        },
+        cwd: dataDir,
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('SecretDir/MySecret1\nSecretDir/NestedDir\n');
+
+      command = [
+        'secrets',
+        'ls',
+        '-np',
+        dataDir,
+        `${vaultName}:SecretDir/NestedDir`,
+      ];
+      result = await testUtils.pkStdio([...command], {
+        env: {
+          PK_PASSWORD: password,
+        },
+        cwd: dataDir,
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('SecretDir/NestedDir/MySecret2\n');
     },
     globalThis.defaultTimeout * 2,
   );

--- a/tests/utils/utils.ts
+++ b/tests/utils/utils.ts
@@ -88,9 +88,9 @@ async function nodesConnect(localNode: PolykeyAgent, remoteNode: PolykeyAgent) {
   );
 }
 
-const secretPathWithoutEnvArb = fc
-  .stringMatching(binParsers.secretPathRegex)
-  .noShrink();
+// This regex defines a vault secret path that always includes the secret path
+const secretPathRegex = /^([\w-]+)(?::)([^\0\\=]+)$/;
+const secretPathWithoutEnvArb = fc.stringMatching(secretPathRegex).noShrink();
 const environmentVariableAre = fc
   .stringMatching(binParsers.environmentVariableRegex)
   .filter((v) => v.length > 0)


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->
This PR works on implementing UNIX-like `secrets ls` experience, as if one was `ls`-ing using the `coreutils`'s `ls` command. As described in the issue spec, not all `ls` commands will be supported, only some major and useful ones.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Relates to #245
* Relates to https://github.com/MatrixAI/Polykey/pull/785
* REF ENG-358

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Add UNIX-like `ls` support
- [x] 2. Confirm file filtering/globbing works
- [x] 3. Add options to render the contents using various flags
- [x] 4. Update all the test

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
