### PR TITLE
Nix module updates

### DIFF
--- a/modules.nix
+++ b/modules.nix
@@ -10,7 +10,6 @@
 
           passwordFilePath = mkOption {
             type = with types; uniq str;
-            default = "/root/.pkpass";
             description = ''
               The path to the Polykey password file. This is required to be set for the module to work, otherwise this module will fail.
             '';
@@ -26,7 +25,6 @@
 
           recoveryCodeOutPath = mkOption {
             type = with types; uniq str;
-            default = "/root/.recoveryout";
             description = ''
               The path to the Polykey recovery code file output location.
             '';
@@ -91,7 +89,6 @@
 
           passwordFilePath = mkOption {
             type = with types; uniq str;
-            default = "%h/.pkpass";
             description = ''
               The path to the Polykey password file. This is required to be set for the module to work, otherwise this module will fail.
             '';
@@ -107,7 +104,6 @@
 
           recoveryCodeOutPath = mkOption {
             type = with types; uniq str;
-            default = "%h/.recoveryout";
             description = ''
               The path to the Polykey recovery code file output location.
             '';
@@ -125,7 +121,11 @@
         home.packages = [ outputs.packages.${system}.default ];
 
         systemd.user.services.polykey = {
-          Unit = { Description = "Polykey Agent"; };
+          Unit = {
+            Description = "Polykey Agent";
+            After = [ "default.target" "network.target" ];
+            Wants = [ "network.target" ];
+          };
           Service = {
             ExecStartPre = ''
               -${outputs.packages.${system}.default}/bin/polykey \
@@ -146,6 +146,7 @@
               --recovery-code-out-file ${config.programs.polykey.recoveryCodeOutPath}
             '';
           };
+          Install = { WantedBy = [ "default.target" ]; };
         };
       };
     };


### PR DESCRIPTION
### Description

This PR updates the NixOS and home manager modules to fix related bugs and issues that were present when using it.

Namely, the user unit service would not run on login, and this PR fixes that. It also reverts back to using manually specified file paths for the password file and other important credentials.

### Tasks

- [x] 1. Make service properly start on login 
- [x] 2. Remove default directories

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
