### PR TITLE
Allow parsing just the vault name without requiring the secret path

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -157,6 +157,21 @@ class ErrorPolykeyCLIMakeDirectory<T> extends ErrorPolykeyCLI<T> {
   exitCode = 1;
 }
 
+class ErrorPolykeyCLIRenameSecret<T> extends ErrorPolykeyCLI<T> {
+  static description = 'Failed to rename one or more secrets';
+  exitCode = 1;
+}
+
+class ErrorPolykeyCLIRemoveSecret<T> extends ErrorPolykeyCLI<T> {
+  static description = 'Failed to remove one or more secrets';
+  exitCode = 1;
+}
+
+class ErrorPolykeyCLICatSecret<T> extends ErrorPolykeyCLI<T> {
+  static description = 'Failed to concatenate one or more secrets';
+  exitCode = 1;
+}
+
 export {
   ErrorPolykeyCLI,
   ErrorPolykeyCLIUncaughtException,
@@ -178,4 +193,7 @@ export {
   ErrorPolykeyCLIInvalidEnvName,
   ErrorPolykeyCLIDuplicateEnvName,
   ErrorPolykeyCLIMakeDirectory,
+  ErrorPolykeyCLIRenameSecret,
+  ErrorPolykeyCLIRemoveSecret,
+  ErrorPolykeyCLICatSecret,
 };

--- a/src/secrets/CommandCreate.ts
+++ b/src/secrets/CommandCreate.ts
@@ -73,7 +73,7 @@ class CommandCreate extends CommandPolykey {
             pkClient.rpcClient.methods.vaultsSecretsNew({
               metadata: auth,
               nameOrId: secretPath[0],
-              secretName: secretPath[1],
+              secretName: secretPath[1] ?? '/',
               secretContent: content.toString('binary'),
             }),
           meta,

--- a/src/secrets/CommandEdit.ts
+++ b/src/secrets/CommandEdit.ts
@@ -17,7 +17,7 @@ class CommandEdit extends CommandPolykey {
     this.argument(
       '<secretPath>',
       'Path to the secret to be edited, specified as <vaultName>:<directoryPath>',
-      binParsers.parseSecretPathValue,
+      binParsers.parseSecretPath,
     );
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
@@ -68,7 +68,7 @@ class CommandEdit extends CommandPolykey {
             const writer = res.writable.getWriter();
             await writer.write({
               nameOrId: secretPath[0],
-              secretName: secretPath[1],
+              secretName: secretPath[1] ?? '/',
               metadata: auth,
             });
             await writer.close();

--- a/src/secrets/CommandList.ts
+++ b/src/secrets/CommandList.ts
@@ -14,12 +14,12 @@ class CommandList extends CommandPolykey {
     this.argument(
       '<directoryPath>',
       'Directory to list files from, specified as <vaultName>[:<path>]',
-      binParsers.parseSecretPathOptional,
+      binParsers.parseSecretPath,
     );
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
-    this.action(async (vaultPattern, options) => {
+    this.action(async (secretPath, options) => {
       const { default: PolykeyClient } = await import(
         'polykey/dist/PolykeyClient'
       );
@@ -52,8 +52,8 @@ class CommandList extends CommandPolykey {
           const secretPaths: Array<string> = [];
           const stream = await pkClient.rpcClient.methods.vaultsSecretsList({
             metadata: auth,
-            nameOrId: vaultPattern[0],
-            secretName: vaultPattern[1] ?? '/',
+            nameOrId: secretPath[0],
+            secretName: secretPath[1] ?? '/',
           });
           for await (const secret of stream) {
             // Remove leading slashes

--- a/src/secrets/CommandRename.ts
+++ b/src/secrets/CommandRename.ts
@@ -4,6 +4,7 @@ import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
 import * as binParsers from '../utils/parsers';
 import * as binProcessors from '../utils/processors';
+import * as errors from '../errors';
 
 class CommandRename extends CommandPolykey {
   constructor(...args: ConstructorParameters<typeof CommandPolykey>) {
@@ -13,13 +14,19 @@ class CommandRename extends CommandPolykey {
     this.argument(
       '<secretPath>',
       'Path to where the secret to be renamed, specified as <vaultName>:<directoryPath>',
-      binParsers.parseSecretPathValue,
+      binParsers.parseSecretPath,
     );
     this.argument('<newSecretName>', 'New name of the secret');
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
     this.action(async (secretPath, newSecretName, options) => {
+      // Ensure that a valid secret path is provided
+      if (secretPath[1] == null) {
+        throw new errors.ErrorPolykeyCLIRenameSecret(
+          'EPERM: Cannot rename vault root',
+        );
+      }
       const { default: PolykeyClient } = await import(
         'polykey/dist/PolykeyClient'
       );

--- a/src/secrets/CommandStat.ts
+++ b/src/secrets/CommandStat.ts
@@ -13,7 +13,7 @@ class CommandStat extends CommandPolykey {
     this.argument(
       '<secretPath>',
       'Path to where the secret, specified as <vaultName>:<directoryPath>',
-      binParsers.parseSecretPathValue,
+      binParsers.parseSecretPath,
     );
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
@@ -55,7 +55,7 @@ class CommandStat extends CommandPolykey {
             pkClient.rpcClient.methods.vaultsSecretsStat({
               metadata: auth,
               nameOrId: secretPath[0],
-              secretName: secretPath[1],
+              secretName: secretPath[1] ?? '/',
             }),
           meta,
         );

--- a/src/secrets/CommandWrite.ts
+++ b/src/secrets/CommandWrite.ts
@@ -13,7 +13,7 @@ class CommandWrite extends CommandPolykey {
     this.argument(
       '<secretPath>',
       'Path to the secret, specified as <vaultName>:<directoryPath>',
-      binParsers.parseSecretPathValue,
+      binParsers.parseSecretPath,
     );
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
@@ -77,7 +77,7 @@ class CommandWrite extends CommandPolykey {
             await pkClient.rpcClient.methods.vaultsSecretsWriteFile({
               metadata: auth,
               nameOrId: secretPath[0],
-              secretName: secretPath[1],
+              secretName: secretPath[1] ?? '/',
               secretContent: stdin,
             }),
           meta,

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -310,7 +310,12 @@ const order = new commander.Option(
 
 const recursive = new commander.Option(
   '--recursive',
-  'If enabled, specified directories will be removed along with their contents',
+  'If enabled, specified operation will be applied recursively to the directory and its contents',
+).default(false);
+
+const parents = new commander.Option(
+  '--parents',
+  'If enabled, create all parent directories as well. If the directories exist, do nothing.',
 ).default(false);
 
 export {
@@ -355,4 +360,5 @@ export {
   limit,
   order,
   recursive,
+  parents,
 };

--- a/src/vaults/CommandList.ts
+++ b/src/vaults/CommandList.ts
@@ -8,8 +8,9 @@ import * as binProcessors from '../utils/processors';
 class CommandList extends CommandPolykey {
   constructor(...args: ConstructorParameters<typeof CommandPolykey>) {
     super(...args);
-    this.name('list');
-    this.description('List all Available Vaults');
+    this.name('ls');
+    this.alias('list');
+    this.description('List all available Vaults');
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);

--- a/tests/secrets/cat.test.ts
+++ b/tests/secrets/cat.test.ts
@@ -40,7 +40,7 @@ describe('commandCatSecret', () => {
     });
   });
   test('should retrieve a secret', async () => {
-    const vaultName = 'Vault3' as VaultName;
+    const vaultName = 'vault' as VaultName;
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
     const secretName = 'secret-name';
     const secretContent = 'this is the contents of the secret';
@@ -60,6 +60,22 @@ describe('commandCatSecret', () => {
     });
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toBe(secretContent);
+  });
+  test('should fail when reading root without secret path', async () => {
+    const vaultName = 'vault' as VaultName;
+    const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
+    const secretName = 'secret-name';
+    const secretContent = 'this is the contents of the secret';
+    await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
+      await vaultOps.addSecret(vault, secretName, secretContent);
+    });
+    const command = ['secrets', 'cat', '-np', dataDir, vaultName];
+    const result = await testUtils.pkStdio(command, {
+      env: { PK_PASSWORD: password },
+      cwd: dataDir,
+    });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toInclude('ErrorSecretsIsDirectory');
   });
   test('should concatenate multiple secrets', async () => {
     const vaultName = 'Vault3' as VaultName;
@@ -132,14 +148,14 @@ describe('commandCatSecret', () => {
       '-np',
       dataDir,
       `${vaultName}:${secretName1}`,
-      `${vaultName}:doesnt-exist-file`,
+      `${vaultName}:doesnt-exist`,
       `${vaultName}:${secretName2}`,
     ];
     const result = await testUtils.pkStdio(command, {
       env: { PK_PASSWORD: password },
       cwd: dataDir,
     });
-    expect(result.exitCode).toBe(0);
+    expect(result.exitCode).toBe(1);
     expect(result.stdout).toBe(`${secretName1}${secretName2}`);
     expect(result.stderr).not.toBe('');
   });
@@ -169,7 +185,7 @@ describe('commandCatSecret', () => {
         resolve(exitCode);
       });
     });
-    expect(exitCode).toStrictEqual(0);
+    expect(exitCode).toBe(0);
     expect(stdout).toBe(stdinData);
   });
 });

--- a/tests/secrets/env.test.ts
+++ b/tests/secrets/env.test.ts
@@ -17,7 +17,6 @@ describe('commandEnv', () => {
   const vaultName = 'vault' as VaultName;
   let dataDir: string;
   let polykeyAgent: PolykeyAgent;
-  let command: Array<string>;
 
   beforeEach(async () => {
     dataDir = await fs.promises.mkdtemp(
@@ -48,12 +47,10 @@ describe('commandEnv', () => {
 
   test('can select 1 env variable', async () => {
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
       await vaultOps.addSecret(vault, 'SECRET', 'this is the secret1');
     });
-
-    command = [
+    const command = [
       'secrets',
       'env',
       '-np',
@@ -66,8 +63,7 @@ describe('commandEnv', () => {
       '-e',
       'console.log(JSON.stringify(process.env))',
     ];
-
-    const result = await testUtils.pkExec([...command], {
+    const result = await testUtils.pkExec(command, {
       env: { PK_PASSWORD: password },
     });
     expect(result.exitCode).toBe(0);
@@ -76,13 +72,11 @@ describe('commandEnv', () => {
   });
   test('can select multiple env variables', async () => {
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
       await vaultOps.addSecret(vault, 'SECRET1', 'this is the secret1');
       await vaultOps.addSecret(vault, 'SECRET2', 'this is the secret2');
     });
-
-    command = [
+    const command = [
       'secrets',
       'env',
       '-np',
@@ -96,8 +90,7 @@ describe('commandEnv', () => {
       '-e',
       'console.log(JSON.stringify(process.env))',
     ];
-
-    const result = await testUtils.pkExec([...command], {
+    const result = await testUtils.pkExec(command, {
       env: { PK_PASSWORD: password },
     });
     expect(result.exitCode).toBe(0);
@@ -107,15 +100,13 @@ describe('commandEnv', () => {
   });
   test('can select a directory of env variables', async () => {
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
       await vaultOps.addSecret(vault, 'SECRET1', 'this is the secret1');
       await vaultOps.mkdir(vault, 'dir1');
       await vaultOps.addSecret(vault, 'dir1/SECRET2', 'this is the secret2');
       await vaultOps.addSecret(vault, 'dir1/SECRET3', 'this is the secret3');
     });
-
-    command = [
+    const command = [
       'secrets',
       'env',
       '-np',
@@ -128,8 +119,7 @@ describe('commandEnv', () => {
       '-e',
       'console.log(JSON.stringify(process.env))',
     ];
-
-    const result = await testUtils.pkExec([...command], {
+    const result = await testUtils.pkExec(command, {
       env: { PK_PASSWORD: password },
     });
     expect(result.exitCode).toBe(0);
@@ -140,12 +130,10 @@ describe('commandEnv', () => {
   });
   test('can select and rename an env variable', async () => {
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
       await vaultOps.addSecret(vault, 'SECRET', 'this is the secret');
     });
-
-    command = [
+    const command = [
       'secrets',
       'env',
       '-np',
@@ -158,8 +146,7 @@ describe('commandEnv', () => {
       '-e',
       'console.log(JSON.stringify(process.env))',
     ];
-
-    const result = await testUtils.pkExec([...command], {
+    const result = await testUtils.pkExec(command, {
       env: { PK_PASSWORD: password },
     });
     expect(result.exitCode).toBe(0);
@@ -169,14 +156,12 @@ describe('commandEnv', () => {
   });
   test('can not rename a directory of env variables', async () => {
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
       await vaultOps.mkdir(vault, 'dir');
       await vaultOps.addSecret(vault, 'dir1/SECRET1', 'this is the secret1');
       await vaultOps.addSecret(vault, 'dir1/SECRET2', 'this is the secret2');
     });
-
-    command = [
+    const command = [
       'secrets',
       'env',
       '-np',
@@ -189,8 +174,7 @@ describe('commandEnv', () => {
       '-e',
       'console.log(JSON.stringify(process.env))',
     ];
-
-    const result = await testUtils.pkExec([...command], {
+    const result = await testUtils.pkExec(command, {
       env: { PK_PASSWORD: password },
     });
     expect(result.exitCode).toBe(0);
@@ -201,7 +185,6 @@ describe('commandEnv', () => {
   });
   test('can mix and match env variables', async () => {
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
       await vaultOps.addSecret(vault, 'SECRET1', 'this is the secret1');
       await vaultOps.addSecret(vault, 'SECRET2', 'this is the secret2');
@@ -209,8 +192,7 @@ describe('commandEnv', () => {
       await vaultOps.addSecret(vault, 'dir1/SECRET3', 'this is the secret3');
       await vaultOps.addSecret(vault, 'dir1/SECRET4', 'this is the secret4');
     });
-
-    command = [
+    const command = [
       'secrets',
       'env',
       '-np',
@@ -225,8 +207,7 @@ describe('commandEnv', () => {
       '-e',
       'console.log(JSON.stringify(process.env))',
     ];
-
-    const result = await testUtils.pkExec([...command], {
+    const result = await testUtils.pkExec(command, {
       env: { PK_PASSWORD: password },
     });
     expect(result.exitCode).toBe(0);
@@ -238,12 +219,10 @@ describe('commandEnv', () => {
   });
   test('existing env are passed through', async () => {
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
       await vaultOps.addSecret(vault, 'SECRET1', 'this is the secret1');
     });
-
-    command = [
+    const command = [
       'secrets',
       'env',
       '-np',
@@ -256,8 +235,7 @@ describe('commandEnv', () => {
       '-e',
       'console.log(JSON.stringify(process.env))',
     ];
-
-    const result = await testUtils.pkExec([...command], {
+    const result = await testUtils.pkExec(command, {
       env: {
         PK_PASSWORD: password,
         EXISTING: 'existing var',
@@ -270,7 +248,6 @@ describe('commandEnv', () => {
   });
   test('handles duplicate secret names', async () => {
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
       await vaultOps.addSecret(vault, 'SECRET1', 'this is the secret1');
       await vaultOps.addSecret(vault, 'SECRET2', 'this is the secret2');
@@ -278,8 +255,7 @@ describe('commandEnv', () => {
       await vaultOps.mkdir(vault, 'dir1');
       await vaultOps.addSecret(vault, 'dir1/SECRET4', 'this is the secret4');
     });
-
-    command = [
+    const command = [
       'secrets',
       'env',
       '-np',
@@ -295,8 +271,7 @@ describe('commandEnv', () => {
       '-e',
       'console.log(JSON.stringify(process.env))',
     ];
-
-    const result = await testUtils.pkExec([...command], {
+    const result = await testUtils.pkExec(command, {
       env: { PK_PASSWORD: password },
     });
     expect(result.exitCode).toBe(0);
@@ -309,7 +284,6 @@ describe('commandEnv', () => {
   });
   test('should output human format', async () => {
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
       await vaultOps.addSecret(vault, 'SECRET1', 'this is the secret1');
       await vaultOps.addSecret(vault, 'SECRET2', 'this is the secret2');
@@ -317,8 +291,7 @@ describe('commandEnv', () => {
       await vaultOps.addSecret(vault, 'dir1/SECRET3', 'this is the secret3');
       await vaultOps.addSecret(vault, 'dir1/SECRET4', 'this is the secret4');
     });
-
-    command = [
+    const command = [
       'secrets',
       'env',
       '-np',
@@ -327,8 +300,7 @@ describe('commandEnv', () => {
       'unix',
       `${vaultName}`,
     ];
-
-    const result = await testUtils.pkExec([...command], {
+    const result = await testUtils.pkExec(command, {
       env: { PK_PASSWORD: password },
     });
     expect(result.exitCode).toBe(0);
@@ -344,7 +316,6 @@ describe('commandEnv', () => {
     const vaultId2 = await polykeyAgent.vaultManager.createVault(
       `${vaultName}2`,
     );
-
     await polykeyAgent.vaultManager.withVaults(
       [vaultId1, vaultId2],
       async (vault1, vault2) => {
@@ -356,8 +327,7 @@ describe('commandEnv', () => {
         await vaultOps.addSecret(vault2, 'dir1/SECRET4', 'this is the secret4');
       },
     );
-
-    command = [
+    const command = [
       'secrets',
       'env',
       '-np',
@@ -367,8 +337,7 @@ describe('commandEnv', () => {
       `${vaultName}1`,
       `${vaultName}2`,
     ];
-
-    const result = await testUtils.pkExec([...command], {
+    const result = await testUtils.pkExec(command, {
       env: { PK_PASSWORD: password },
     });
     expect(result.exitCode).toBe(0);
@@ -384,7 +353,6 @@ describe('commandEnv', () => {
     const vaultId2 = await polykeyAgent.vaultManager.createVault(
       `${vaultName}2`,
     );
-
     await polykeyAgent.vaultManager.withVaults(
       [vaultId1, vaultId2],
       async (vault1, vault2) => {
@@ -396,8 +364,7 @@ describe('commandEnv', () => {
         await vaultOps.addSecret(vault2, 'dir1/SECRET4', 'this is the secret4');
       },
     );
-
-    command = [
+    const command = [
       'secrets',
       'env',
       '-np',
@@ -407,8 +374,7 @@ describe('commandEnv', () => {
       `${vaultName}1`,
       `${vaultName}2`,
     ];
-
-    const result = await testUtils.pkExec([...command], {
+    const result = await testUtils.pkExec(command, {
       env: { PK_PASSWORD: password },
     });
     expect(result.exitCode).toBe(0);
@@ -424,7 +390,6 @@ describe('commandEnv', () => {
     const vaultId2 = await polykeyAgent.vaultManager.createVault(
       `${vaultName}2`,
     );
-
     await polykeyAgent.vaultManager.withVaults(
       [vaultId1, vaultId2],
       async (vault1, vault2) => {
@@ -436,8 +401,7 @@ describe('commandEnv', () => {
         await vaultOps.addSecret(vault2, 'dir1/SECRET4', 'this is the secret4');
       },
     );
-
-    command = [
+    const command = [
       'secrets',
       'env',
       '-np',
@@ -447,8 +411,7 @@ describe('commandEnv', () => {
       `${vaultName}1`,
       `${vaultName}2`,
     ];
-
-    const result = await testUtils.pkExec([...command], {
+    const result = await testUtils.pkExec(command, {
       env: { PK_PASSWORD: password },
     });
     expect(result.exitCode).toBe(0);
@@ -459,7 +422,6 @@ describe('commandEnv', () => {
   });
   test('should output json format', async () => {
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
       await vaultOps.addSecret(vault, 'SECRET1', 'this is the secret1');
       await vaultOps.addSecret(vault, 'SECRET2', 'this is the secret2');
@@ -467,8 +429,7 @@ describe('commandEnv', () => {
       await vaultOps.addSecret(vault, 'dir1/SECRET3', 'this is the secret3');
       await vaultOps.addSecret(vault, 'dir1/SECRET4', 'this is the secret4');
     });
-
-    command = [
+    const command = [
       'secrets',
       'env',
       '-np',
@@ -477,8 +438,7 @@ describe('commandEnv', () => {
       'json',
       `${vaultName}`,
     ];
-
-    const result = await testUtils.pkExec([...command], {
+    const result = await testUtils.pkExec(command, {
       env: { PK_PASSWORD: password },
     });
     expect(result.exitCode).toBe(0);
@@ -491,11 +451,9 @@ describe('commandEnv', () => {
   });
   test('testing valid and invalid rename inputs', async () => {
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
       await vaultOps.addSecret(vault, 'SECRET', 'this is the secret');
     });
-
     const valid = [
       'one',
       'ONE',
@@ -506,88 +464,79 @@ describe('commandEnv', () => {
       'ONE123',
       'ONE_123',
     ];
-
     const invalid = ['123', '123abc', '123_123', '123_abc', '123 abc', ' '];
-
+    const validCommand = [
+      'secrets',
+      'env',
+      '-np',
+      dataDir,
+      '--env-format',
+      'unix',
+      ...valid.map((v) => `${vaultName}:SECRET=${v}`),
+    ];
     // Checking valid
-    const result = await testUtils.pkExec(
-      [
+    const result = await testUtils.pkExec(validCommand, {
+      env: { PK_PASSWORD: password },
+    });
+    expect(result.exitCode).toBe(0);
+    // Checking invalid
+    for (const nameNew of invalid) {
+      const invalidCommand = [
         'secrets',
         'env',
         '-np',
         dataDir,
         '--env-format',
         'unix',
-        ...valid.map((v) => `${vaultName}:SECRET=${v}`),
-      ],
-      { env: { PK_PASSWORD: password } },
-    );
-    expect(result.exitCode).toBe(0);
-
-    // Checking invalid
-    for (const nameNew of invalid) {
-      const result = await testUtils.pkExec(
-        [
-          'secrets',
-          'env',
-          '-np',
-          dataDir,
-          '--env-format',
-          'unix',
-          '-e',
-          `${vaultName}:SECRET=${nameNew}`,
-        ],
-        { env: { PK_PASSWORD: password } },
-      );
+        '-e',
+        `${vaultName}:SECRET=${nameNew}`,
+      ];
+      const result = await testUtils.pkExec(invalidCommand, {
+        env: { PK_PASSWORD: password },
+      });
       expect(result.exitCode).toBe(sysexits.USAGE);
     }
   });
   test('invalid handled with error', async () => {
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
       await vaultOps.addSecret(vault, '123', 'this is an invalid secret');
     });
-
-    // Checking valid
-    const result = await testUtils.pkExec(
-      [
-        'secrets',
-        'env',
-        '-np',
-        dataDir,
-        '--env-format',
-        'unix',
-        '-ei',
-        'error',
-        `${vaultName}`,
-      ],
-      { env: { PK_PASSWORD: password } },
-    );
+    const command = [
+      'secrets',
+      'env',
+      '-np',
+      dataDir,
+      '--env-format',
+      'unix',
+      '-ei',
+      'error',
+      `${vaultName}`,
+    ];
+    const result = await testUtils.pkExec(command, {
+      env: { PK_PASSWORD: password },
+    });
     expect(result.exitCode).toBe(64);
   });
   test('invalid handled with warn', async () => {
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
       await vaultOps.addSecret(vault, '123', 'this is an invalid secret');
     });
-
-    // Checking valid
-    const result = await testUtils.pkExec(
-      [
-        'secrets',
-        'env',
-        '-np',
-        dataDir,
-        '--env-format',
-        'unix',
-        '-ei',
-        'warn',
-        `${vaultName}`,
-      ],
-      { env: { PK_PASSWORD: password } },
-    );
+    const command = [
+      'secrets',
+      'env',
+      '-np',
+      dataDir,
+      '--env-format',
+      'unix',
+      '-ei',
+      'warn',
+      `${vaultName}`,
+    ];
+    const result = await testUtils.pkExec(command, {
+      env: { PK_PASSWORD: password },
+    });
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toBe('');
     expect(result.stderr).toInclude(
@@ -596,26 +545,24 @@ describe('commandEnv', () => {
   });
   test('invalid handled with ignore', async () => {
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
       await vaultOps.addSecret(vault, '123', 'this is an invalid secret');
     });
 
-    // Checking valid
-    const result = await testUtils.pkExec(
-      [
-        'secrets',
-        'env',
-        '-np',
-        dataDir,
-        '--env-format',
-        'unix',
-        '-ei',
-        'ignore',
-        `${vaultName}`,
-      ],
-      { env: { PK_PASSWORD: password } },
-    );
+    const command = [
+      'secrets',
+      'env',
+      '-np',
+      dataDir,
+      '--env-format',
+      'unix',
+      '-ei',
+      'ignore',
+      `${vaultName}`,
+    ];
+    const result = await testUtils.pkExec(command, {
+      env: { PK_PASSWORD: password },
+    });
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toBe('');
     expect(result.stderr).not.toInclude(
@@ -624,55 +571,49 @@ describe('commandEnv', () => {
   });
   test('duplicate handled with error', async () => {
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
       await vaultOps.addSecret(vault, 'secret', 'this is a secret');
       await vaultOps.mkdir(vault, 'dir');
       await vaultOps.addSecret(vault, 'dir/secret', 'this is a secret');
     });
-
-    // Checking valid
-    const result = await testUtils.pkExec(
-      [
-        'secrets',
-        'env',
-        '-np',
-        dataDir,
-        '--env-format',
-        'unix',
-        '-ed',
-        'error',
-        `${vaultName}`,
-      ],
-      { env: { PK_PASSWORD: password } },
-    );
+    const command = [
+      'secrets',
+      'env',
+      '-np',
+      dataDir,
+      '--env-format',
+      'unix',
+      '-ed',
+      'error',
+      `${vaultName}`,
+    ];
+    const result = await testUtils.pkExec(command, {
+      env: { PK_PASSWORD: password },
+    });
     expect(result.exitCode).toBe(64);
     expect(result.stderr).toInclude('ErrorPolykeyCLIDuplicateEnvName');
   });
   test('duplicate handled with warn', async () => {
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
       await vaultOps.addSecret(vault, 'secret', 'this is a secret');
       await vaultOps.mkdir(vault, 'dir');
       await vaultOps.addSecret(vault, 'dir/secret', 'this is a secret');
     });
-
-    // Checking valid
-    const result = await testUtils.pkExec(
-      [
-        'secrets',
-        'env',
-        '-np',
-        dataDir,
-        '--env-format',
-        'unix',
-        '-ed',
-        'warn',
-        `${vaultName}`,
-      ],
-      { env: { PK_PASSWORD: password } },
-    );
+    const command = [
+      'secrets',
+      'env',
+      '-np',
+      dataDir,
+      '--env-format',
+      'unix',
+      '-ed',
+      'warn',
+      `${vaultName}`,
+    ];
+    const result = await testUtils.pkExec(command, {
+      env: { PK_PASSWORD: password },
+    });
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toInclude(
       'The env variable (secret) is duplicate, overwriting',
@@ -680,61 +621,54 @@ describe('commandEnv', () => {
   });
   test('duplicate handled with keep', async () => {
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
       await vaultOps.addSecret(vault, 'secret', 'this is a secret1');
       await vaultOps.mkdir(vault, 'dir');
       await vaultOps.addSecret(vault, 'dir/secret', 'this is a secret2');
     });
-
-    // Checking valid
-    const result = await testUtils.pkExec(
-      [
-        'secrets',
-        'env',
-        '-np',
-        dataDir,
-        '--env-format',
-        'unix',
-        '-ed',
-        'keep',
-        `${vaultName}`,
-      ],
-      { env: { PK_PASSWORD: password } },
-    );
+    const command = [
+      'secrets',
+      'env',
+      '-np',
+      dataDir,
+      '--env-format',
+      'unix',
+      '-ed',
+      'keep',
+      `${vaultName}`,
+    ];
+    const result = await testUtils.pkExec(command, {
+      env: { PK_PASSWORD: password },
+    });
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toInclude('this is a secret1');
   });
   test('duplicate handled with overwrite', async () => {
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
       await vaultOps.addSecret(vault, 'secret', 'this is a secret1');
       await vaultOps.mkdir(vault, 'dir');
       await vaultOps.addSecret(vault, 'dir/secret', 'this is a secret2');
     });
-
-    // Checking valid
-    const result = await testUtils.pkExec(
-      [
-        'secrets',
-        'env',
-        '-np',
-        dataDir,
-        '--env-format',
-        'unix',
-        '-ed',
-        'overwrite',
-        `${vaultName}`,
-      ],
-      { env: { PK_PASSWORD: password } },
-    );
+    const command = [
+      'secrets',
+      'env',
+      '-np',
+      dataDir,
+      '--env-format',
+      'unix',
+      '-ed',
+      'overwrite',
+      `${vaultName}`,
+    ];
+    const result = await testUtils.pkExec(command, {
+      env: { PK_PASSWORD: password },
+    });
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toInclude('this is a secret2');
   });
   test('newlines in secrets are untouched', async () => {
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
       await vaultOps.addSecret(
         vault,
@@ -742,8 +676,7 @@ describe('commandEnv', () => {
         'this is a secret\nit has multiple lines\n',
       );
     });
-
-    command = [
+    const command = [
       'secrets',
       'env',
       '-np',
@@ -756,8 +689,7 @@ describe('commandEnv', () => {
       '-e',
       'console.log(JSON.stringify(process.env))',
     ];
-
-    const result = await testUtils.pkExec([...command], {
+    const result = await testUtils.pkExec(command, {
       env: { PK_PASSWORD: password },
     });
     expect(result.exitCode).toBe(0);
@@ -792,15 +724,14 @@ describe('commandEnv', () => {
     },
   );
   test('handles no arguments', async () => {
-    command = ['secrets', 'env', '-np', dataDir, '--env-format', 'unix'];
-
-    const result1 = await testUtils.pkExec([...command], {
+    const command = ['secrets', 'env', '-np', dataDir, '--env-format', 'unix'];
+    const result1 = await testUtils.pkExec(command, {
       env: { PK_PASSWORD: password },
     });
     expect(result1.exitCode).toBe(64);
   });
   test('handles providing no secret paths', async () => {
-    command = [
+    const command = [
       'secrets',
       'env',
       '-np',
@@ -810,8 +741,7 @@ describe('commandEnv', () => {
       '--',
       'someCommand',
     ];
-
-    const result1 = await testUtils.pkExec([...command], {
+    const result1 = await testUtils.pkExec(command, {
       env: { PK_PASSWORD: password },
     });
     expect(result1.exitCode).toBe(64);
@@ -823,7 +753,6 @@ describe('commandEnv', () => {
     const vaultId2 = await polykeyAgent.vaultManager.createVault(
       `${vaultName}2`,
     );
-
     await polykeyAgent.vaultManager.withVaults(
       [vaultId1, vaultId2],
       async (vault1, vault2) => {
@@ -835,8 +764,7 @@ describe('commandEnv', () => {
         await vaultOps.addSecret(vault2, 'dir1/SECRET4', 'this is the secret4');
       },
     );
-
-    command = [
+    const command = [
       'secrets',
       'env',
       '-np',
@@ -846,8 +774,7 @@ describe('commandEnv', () => {
       `${vaultName}1`,
       `${vaultName}2`,
     ];
-
-    const result = await testUtils.pkExec([...command], {
+    const result = await testUtils.pkExec(command, {
       env: { PK_PASSWORD: password },
     });
     expect(result.exitCode).toBe(0);

--- a/tests/secrets/mkdir.test.ts
+++ b/tests/secrets/mkdir.test.ts
@@ -46,7 +46,7 @@ describe('commandMkdir', () => {
     const dirName = 'dir';
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
     command = ['secrets', 'mkdir', '-np', dataDir, `${vaultName}:${dirName}`];
-    const result = await testUtils.pkStdio([...command], {
+    const result = await testUtils.pkStdio(command, {
       env: { PK_PASSWORD: password },
       cwd: dataDir,
     });
@@ -54,6 +54,20 @@ describe('commandMkdir', () => {
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
       const stat = await vaultOps.statSecret(vault, dirName);
       expect(stat.isDirectory()).toBeTruthy();
+    });
+  });
+  test('should fail when provided only the vault name', async () => {
+    const vaultName = 'vault' as VaultName;
+    const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
+    command = ['secrets', 'mkdir', '-np', dataDir, vaultName];
+    const result = await testUtils.pkStdio(command, {
+      env: { PK_PASSWORD: password },
+      cwd: dataDir,
+    });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toInclude('EEXIST'); // Root directory is already a directory
+    await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
+      expect(await vaultOps.listSecrets(vault)).toEqual([]);
     });
   });
   test('should make directories recursively', async () => {
@@ -68,9 +82,9 @@ describe('commandMkdir', () => {
       '-np',
       dataDir,
       `${vaultName}:${dirNameNested}`,
-      '--recursive',
+      '--parents',
     ];
-    const result = await testUtils.pkStdio([...command], {
+    const result = await testUtils.pkStdio(command, {
       env: { PK_PASSWORD: password },
       cwd: dataDir,
     });
@@ -95,7 +109,7 @@ describe('commandMkdir', () => {
       dataDir,
       `${vaultName}:${dirNameNested}`,
     ];
-    const result = await testUtils.pkStdio([...command], {
+    const result = await testUtils.pkStdio(command, {
       env: { PK_PASSWORD: password },
       cwd: dataDir,
     });
@@ -120,7 +134,7 @@ describe('commandMkdir', () => {
       });
     });
     command = ['secrets', 'mkdir', '-np', dataDir, `${vaultName}:${dirName}`];
-    const result = await testUtils.pkStdio([...command], {
+    const result = await testUtils.pkStdio(command, {
       env: { PK_PASSWORD: password },
       cwd: dataDir,
     });
@@ -150,7 +164,7 @@ describe('commandMkdir', () => {
       dataDir,
       `${vaultName}:${secretName}`,
     ];
-    const result = await testUtils.pkStdio([...command], {
+    const result = await testUtils.pkStdio(command, {
       env: { PK_PASSWORD: password },
       cwd: dataDir,
     });
@@ -182,7 +196,7 @@ describe('commandMkdir', () => {
       `${vaultName2}:${dirName2}`,
       `${vaultName1}:${dirName3}`,
     ];
-    const result = await testUtils.pkStdio([...command], {
+    const result = await testUtils.pkStdio(command, {
       env: { PK_PASSWORD: password },
       cwd: dataDir,
     });
@@ -218,7 +232,7 @@ describe('commandMkdir', () => {
       `${vaultName2}:${dirName3}`,
       `${vaultName1}:${dirName4}`,
     ];
-    const result = await testUtils.pkStdio([...command], {
+    const result = await testUtils.pkStdio(command, {
       env: { PK_PASSWORD: password },
       cwd: dataDir,
     });

--- a/tests/secrets/write.test.ts
+++ b/tests/secrets/write.test.ts
@@ -68,7 +68,6 @@ describe('commandWriteFile', () => {
         dataDir,
         `${vaultName}:${secretName}`,
       ];
-
       const childProcess = await testUtils.pkSpawn(
         command,
         {
@@ -95,6 +94,34 @@ describe('commandWriteFile', () => {
       });
     },
   );
+  test.prop([stdinArb], { numRuns: 1 })(
+    'should fail writing when secret path is not specified',
+    async (stdinData) => {
+      const vaultName = genVaultName();
+      await polykeyAgent.vaultManager.createVault(vaultName);
+      command = ['secrets', 'write', '-np', dataDir, vaultName];
+      const childProcess = await testUtils.pkSpawn(
+        command,
+        {
+          env: { PK_PASSWORD: password },
+          cwd: dataDir,
+        },
+        logger,
+      );
+      // The conditions of stdin being null will not be met in the test, so we
+      // don't have to worry about the fields being null.
+      childProcess.stdin!.write(stdinData);
+      childProcess.stdin!.end();
+      const exitCode = await new Promise((resolve) => {
+        childProcess.once('exit', (code) => {
+          const exitCode = code ?? -255;
+          childProcess.removeAllListeners('data');
+          resolve(exitCode);
+        });
+      });
+      expect(exitCode).not.toBe(0);
+    },
+  );
   test('should overwrite secret', async () => {
     const vaultName = 'vault' as VaultName;
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
@@ -107,7 +134,6 @@ describe('commandWriteFile', () => {
       dataDir,
       `${vaultName}:${secretName}`,
     ];
-
     const childProcess = await testUtils.pkSpawn(
       command,
       {


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->
When specifying a secret path, currently the format needs to be `<vaultName>:<secretPath>`, otherwise a parser error is thrown. This should not be the case, and instead paths like `<vaultName>` should also be allowed, which would point to the root of the directory.

To do this, a parser for `vaultName` will also be implemented, ensuring consistency in vault's allowed characters. This is important as currently, there are no parsers for vault name, but there is a regex validation for vault names when they are being used in the secret commands. This means that inadvertently vaults can be created which cannot be actually used in any commands like `matrix.ai`.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Relates to <b>[Polykey-CLI#304](https://github.com/MatrixAI/Polykey-CLI/issues/304)</b> (REF ENG-425)
* Relates to <b>[Polykey-CLI#251](https://github.com/MatrixAI/Polykey-CLI/issues/251)</b> (REF ENG-379)
* Closes <b>[Polykey-CLI#310](https://github.com/MatrixAI/Polykey-CLI/issues/310)</b> (REF ENG-431)

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Create parser for vaultName
- [x] 2. Use the vaultName parser to parse the vault name consistently in vault and secret commands
- [x] 3. Make the default parser accept missing secret names
- [x] 4. Convert each command to use this new parser and substitute `'/'` if the secret path is undefined
- [x] 5. Run tests to ensure no regression
- [x] 6. Add tests for parsers
- ~~`[ ]` 7. Split tests for `vaults/scanNode.test.ts`~~ out of scope for this PR
- [x] 8. Add tests for every handler to confirm no secret to be an alias for the root directory
  - [x] `cat`
  - [x] `create`
  - [x] `dir`
  - [x] `edit`
  - [x] `env`
  - [x] `list`
  - [x] `mkdir`
  - [x] `remove`
  - [x] `rename`
  - [x] `stat`
  - [x] `write`
- [x] 9. Change `vaults list` to `vaults ls` 


### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
