### PR TITLE
Using logger methods for agent shutdown messaging

### DIFF
--- a/src/agent/CommandStart.ts
+++ b/src/agent/CommandStart.ts
@@ -253,7 +253,7 @@ class CommandStart extends CommandPolykey {
         pkAgent.addEventListener(
           polykeyEvents.EventPolykeyAgentStop.name,
           () => {
-            process.stderr.write('Stopping Agent\n');
+            this.logger.warn('Stopping Agent');
           },
           { once: true },
         );

--- a/src/agent/CommandStop.ts
+++ b/src/agent/CommandStop.ts
@@ -27,10 +27,10 @@ class CommandStop extends CommandPolykey {
       );
       const statusInfo = clientStatus.statusInfo;
       if (statusInfo?.status === 'DEAD') {
-        process.stderr.write('Agent is already dead\n');
+        this.logger.warn('Agent is already dead');
         return;
       } else if (statusInfo?.status === 'STOPPING') {
-        process.stderr.write('Agent is already stopping\n');
+        this.logger.warn('Agent is already stopping');
         return;
       } else if (statusInfo?.status === 'STARTING') {
         throw new errors.ErrorPolykeyCLIAgentStatus('Agent is starting');
@@ -62,7 +62,7 @@ class CommandStop extends CommandPolykey {
             }),
           auth,
         );
-        process.stderr.write('Stopping Agent\n');
+        this.logger.warn('Stopping Agent');
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/vaults/CommandCreate.ts
+++ b/src/vaults/CommandCreate.ts
@@ -10,7 +10,6 @@ class CommandCreate extends CommandPolykey {
   constructor(...args: ConstructorParameters<typeof CommandPolykey>) {
     super(...args);
     this.name('create');
-    this.aliases(['touch']);
     this.description('Create a new Vault');
     this.argument(
       '<vaultName>',

--- a/src/vaults/CommandRemove.ts
+++ b/src/vaults/CommandRemove.ts
@@ -8,11 +8,12 @@ import * as binParsers from '../utils/parsers';
 class CommandDelete extends CommandPolykey {
   constructor(...args: ConstructorParameters<typeof CommandPolykey>) {
     super(...args);
-    this.name('delete');
-    this.description('Delete an Existing Vault');
+    this.name('rm');
+    this.alias('remove');
+    this.description('Remove an existing Vault');
     this.argument(
       '<vaultName>',
-      'Name of the vault to be deleted',
+      'Name of the vault to be removed',
       binParsers.parseVaultName,
     );
     this.addOption(binOptions.nodeId);

--- a/src/vaults/CommandVaults.ts
+++ b/src/vaults/CommandVaults.ts
@@ -1,11 +1,11 @@
 import CommandClone from './CommandClone';
 import CommandCreate from './CommandCreate';
-import CommandDelete from './CommandDelete';
 import CommandList from './CommandList';
 import CommandLog from './CommandLog';
 import CommandScan from './CommandScan';
 import CommandPermissions from './CommandPermissions';
 import CommandPull from './CommandPull';
+import CommandRemove from './CommandRemove';
 import CommandRename from './CommandRename';
 import CommandShare from './CommandShare';
 import CommandUnshare from './CommandUnshare';
@@ -19,11 +19,11 @@ class CommandVaults extends CommandPolykey {
     this.description('Vaults Operations');
     this.addCommand(new CommandClone(...args));
     this.addCommand(new CommandCreate(...args));
-    this.addCommand(new CommandDelete(...args));
     this.addCommand(new CommandList(...args));
     this.addCommand(new CommandLog(...args));
     this.addCommand(new CommandPermissions(...args));
     this.addCommand(new CommandPull(...args));
+    this.addCommand(new CommandRemove(...args));
     this.addCommand(new CommandRename(...args));
     this.addCommand(new CommandShare(...args));
     this.addCommand(new CommandUnshare(...args));

--- a/tests/vaults/create.test.ts
+++ b/tests/vaults/create.test.ts
@@ -65,21 +65,11 @@ describe('commandCreateVaults', () => {
       cwd: dataDir,
     });
     expect(result.exitCode).toBe(0);
-    const result2 = await testUtils.pkStdio(
-      ['vaults', 'touch', '-np', dataDir, 'MyTestVault2'],
-      {
-        env: { PK_PASSWORD: password },
-        cwd: dataDir,
-      },
-    );
-    expect(result2.exitCode).toBe(0);
-
     const list = (await polykeyAgent.vaultManager.listVaults()).keys();
     const namesList: string[] = [];
     for await (const name of list) {
       namesList.push(name);
     }
     expect(namesList).toContain('MyTestVault');
-    expect(namesList).toContain('MyTestVault2');
   });
 });

--- a/tests/vaults/remove.test.ts
+++ b/tests/vaults/remove.test.ts
@@ -8,7 +8,7 @@ import * as ids from 'polykey/dist/ids';
 import * as keysUtils from 'polykey/dist/keys/utils';
 import * as testUtils from '../utils';
 
-describe('commandDeleteVault', () => {
+describe('commandRemoveVault', () => {
   const password = 'password';
   const logger = new Logger('CLI Test', LogLevel.WARN, [new StreamHandler()]);
   let dataDir: string;
@@ -68,8 +68,8 @@ describe('commandDeleteVault', () => {
     });
   });
 
-  test('should delete vault', async () => {
-    command = ['vaults', 'delete', '-np', dataDir, vaultName];
+  test('should remove vault', async () => {
+    command = ['vaults', 'rm', '-np', dataDir, vaultName];
     await polykeyAgent.vaultManager.createVault(vaultName);
     let id = polykeyAgent.vaultManager.getVaultId(vaultName);
     expect(id).toBeTruthy();


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->

Currently, the status of the logger is directly written to the standard error using `proces.stderr.write()`, but that is not ideal. We should be using `logger` for all messaging and communication.

This PR changes the `'Stopping Agent'` message when stopping the agent from writing to standard error to using logger to do it.

As #323 is a small change, it will be done alongside this PR, too.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #323 (REF ENG-455)
* Fixes #270 (REF ENG-399)

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Remove `process.stderr.write()` and replace it with `logger.warn`
- [x] 2. All the commands which should have a short/long form must have it. For example, `vaults rm|remove`, etc.

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
