### PR TITLE
Remove newlines by default when exporting contents using `secrets env`

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -84,6 +84,11 @@ class ErrorPolykeyCLIUnexpectedError<T> extends ErrorPolykeyCLI<T> {
   exitCode = sysexits.SOFTWARE;
 }
 
+class ErrorPolykeyCLISubprocessFailure<T> extends ErrorPolykeyCLI<T> {
+  static description = 'A subprocess failed to exit gracefully';
+  exitCode = sysexits.UNKNOWN;
+}
+
 class ErrorPolykeyCLINodePath<T> extends ErrorPolykeyCLI<T> {
   static description = 'Cannot derive default node path from unknown platform';
   exitCode = sysexits.USAGE;
@@ -191,6 +196,7 @@ export {
   ErrorPolykeyCLIUncaughtException,
   ErrorPolykeyCLIUnhandledRejection,
   ErrorPolykeyCLIUnexpectedError,
+  ErrorPolykeyCLISubprocessFailure,
   ErrorPolykeyCLIAsynchronousDeadlock,
   ErrorPolykeyCLINodePath,
   ErrorPolykeyCLIClientOptions,

--- a/src/identities/CommandDiscover.ts
+++ b/src/identities/CommandDiscover.ts
@@ -103,8 +103,8 @@ class CommandDiscover extends CommandPolykey {
                   case 'queued':
                     queuedSet.add(vertex);
                     break;
-                  case 'processed':
-                  case 'cancelled':
+                  case 'processed': // Fallthrough
+                  case 'cancelled': // Fallthrough
                   case 'failed':
                     queuedSet.delete(vertex);
                     break;

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,8 @@ type PromiseDeconstructed<T> = {
   rejectP: (reason?: any) => void;
 };
 
+type ParsedSecretPathValue = [string, string?, string?];
+
 export type {
   TableRow,
   TableOptions,
@@ -69,4 +71,5 @@ export type {
   AgentChildProcessInput,
   AgentChildProcessOutput,
   PromiseDeconstructed,
+  ParsedSecretPathValue,
 };

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -318,6 +318,17 @@ const parents = new commander.Option(
   'If enabled, create all parent directories as well. If the directories exist, do nothing.',
 ).default(false);
 
+const preserveNewline = new commander.Option(
+  '-pn --preserve-newline <path>',
+  'Preserve the last trailing newline for the secret content',
+)
+  .argParser((value: string, previous: Array<[string, string?, string?]>) => {
+    const out = previous ?? [];
+    out.push(binParsers.parseSecretPathEnv(value));
+    return out;
+  })
+  .default([]);
+
 export {
   nodePath,
   format,
@@ -361,4 +372,5 @@ export {
   order,
   recursive,
   parents,
+  preserveNewline,
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -155,9 +155,9 @@ function encodeEscaped(str: string): string {
         return '\\v'; // Encode tab
       case '\f':
         return '\\f'; // Encode tab
-      case '"':
-      case "'":
-      case '`':
+      case '"': // Fallthrough
+      case "'": // Fallthrough
+      case '`': // Fallthrough
       case '\\':
         return '\\' + char;
       // Add cases for other whitespace characters if needed
@@ -202,9 +202,9 @@ function decodeEscaped(str: string): string {
         return '\v';
       case 'f':
         return '\f';
-      case '"':
-      case "'":
-      case '`':
+      case '"': // Fallthrough
+      case "'": // Fallthrough
+      case '`': // Fallthrough
       case '\\':
         return lastChar;
     }
@@ -448,7 +448,11 @@ function outputFormatterError(err: any): string {
         }
         output += `${indent}timestamp\t${err.timestamp}\n`;
       } else {
-        output += '\n';
+        if (err.data && !utils.isEmptyObject(err.data)) {
+          output += `\n${indent}data: ${JSON.stringify(err.data)}\n`;
+        } else {
+          output += '\n';
+        }
       }
       output += `${indent}cause: `;
       err = err.cause;
@@ -504,10 +508,10 @@ function outputFormatterError(err: any): string {
 
 function composeErrorMessage(error: any) {
   switch (typeof error) {
-    case 'boolean':
-    case 'number':
-    case 'string':
-    case 'bigint':
+    case 'boolean': // Fallthrough
+    case 'number': // Fallthrough
+    case 'string': // Fallthrough
+    case 'bigint': // Fallthrough
     case 'symbol':
       return `Thrown non-error literal '${String(error)}'`;
     case 'object':

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -8,6 +8,7 @@ import * as polykeyErrors from 'polykey/dist/errors';
 import * as fc from 'fast-check';
 import * as binUtils from '@/utils/utils';
 import * as binParsers from '@/utils/parsers';
+import * as testUtils from './utils';
 
 describe('outputFormatters', () => {
   const nonPrintableCharArb = fc
@@ -329,10 +330,6 @@ describe('outputFormatters', () => {
 });
 
 describe('parsers', () => {
-  const vaultNameArb = fc.stringOf(
-    fc.char().filter((c) => binParsers.vaultNameRegex.test(c)),
-    { minLength: 1, maxLength: 100 },
-  );
   const singleSecretPathArb = fc.stringOf(
     fc.char().filter((c) => binParsers.secretPathRegex.test(c)),
     { minLength: 1, maxLength: 25 },
@@ -349,20 +346,20 @@ describe('parsers', () => {
     .tuple(valueFirstCharArb, valueRestCharArb)
     .map((components) => components.join(''));
 
-  test.prop([vaultNameArb], { numRuns: 100 })(
+  test.prop([testUtils.vaultNameArb], { numRuns: 100 })(
     'should parse vault name',
     async (vaultName) => {
       expect(binParsers.parseVaultName(vaultName)).toEqual(vaultName);
     },
   );
-  test.prop([vaultNameArb], { numRuns: 10 })(
+  test.prop([testUtils.vaultNameArb], { numRuns: 10 })(
     'should parse secret path with only vault name',
     async (vaultName) => {
       const result = [vaultName, undefined, undefined];
       expect(binParsers.parseSecretPath(vaultName)).toEqual(result);
     },
   );
-  test.prop([vaultNameArb, secretPathArb], { numRuns: 100 })(
+  test.prop([testUtils.vaultNameArb, secretPathArb], { numRuns: 100 })(
     'should parse full secret path with vault name',
     async (vaultName, secretPath) => {
       const query = `${vaultName}:${secretPath}`;
@@ -370,7 +367,9 @@ describe('parsers', () => {
       expect(binParsers.parseSecretPath(query)).toEqual(result);
     },
   );
-  test.prop([vaultNameArb, secretPathArb, valueDataArb], { numRuns: 100 })(
+  test.prop([testUtils.vaultNameArb, secretPathArb, valueDataArb], {
+    numRuns: 100,
+  })(
     'should parse full secret path with vault name and value',
     async (vaultName, secretPath, valueData) => {
       const query = `${vaultName}:${secretPath}=${valueData}`;

--- a/tests/utils/utils.ts
+++ b/tests/utils/utils.ts
@@ -112,6 +112,11 @@ const cmdArgsArrayArb = fc
   })
   .noShrink();
 
+const vaultNameArb = fc
+  .string({ minLength: 1, maxLength: 100 })
+  .filter((str) => binParsers.vaultNameRegex.test(str))
+  .noShrink();
+
 export {
   testIf,
   describeIf,
@@ -120,4 +125,5 @@ export {
   secretPathEnvArb,
   secretPathEnvArrayArb,
   cmdArgsArrayArb,
+  vaultNameArb,
 };


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->

The standard to end all files in Unix is adding a newline at the end of the file. All editors, including `vim` do it. However, adding a stray newline at the end of a secret, like a password, can have adverse effects.

As such, this PR will, by default, trim the single trailing newline, with an option to disable it if needed.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #296 (REF ENG-416)
* Related to #325 (REF ENG-466)

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Remove newlines by default
- [x] 2. Add a new option to allow preserving newlines
- [x] 3. Add tests ensuring this behaviour

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
