### PR TITLE
Use a single `--` instead of needing double `--` to separate commands

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -84,8 +84,8 @@ class ErrorPolykeyCLIUnexpectedError<T> extends ErrorPolykeyCLI<T> {
   exitCode = sysexits.SOFTWARE;
 }
 
-class ErrorPolykeyCLISubprocessFailure<T> extends ErrorPolykeyCLI<T> {
-  static description = 'A subprocess failed to exit gracefully';
+class ErrorPolykeyCLIChildProcessFailure<T> extends ErrorPolykeyCLI<T> {
+  static description = 'A child process failed to exit gracefully';
   exitCode = sysexits.UNKNOWN;
 }
 
@@ -196,7 +196,7 @@ export {
   ErrorPolykeyCLIUncaughtException,
   ErrorPolykeyCLIUnhandledRejection,
   ErrorPolykeyCLIUnexpectedError,
-  ErrorPolykeyCLISubprocessFailure,
+  ErrorPolykeyCLIChildProcessFailure,
   ErrorPolykeyCLIAsynchronousDeadlock,
   ErrorPolykeyCLINodePath,
   ErrorPolykeyCLIClientOptions,

--- a/src/secrets/CommandEdit.ts
+++ b/src/secrets/CommandEdit.ts
@@ -120,7 +120,7 @@ class CommandEdit extends CommandPolykey {
           };
           const onError = (e: Error) => {
             cleanup();
-            const error = new errors.ErrorPolykeyCLISubprocessFailure(
+            const error = new errors.ErrorPolykeyCLIChildProcessFailure(
               `Failed to run command '${process.env.EDITOR}'`,
               { cause: e },
             );
@@ -129,7 +129,7 @@ class CommandEdit extends CommandPolykey {
           const onClose = (code: number | null) => {
             cleanup();
             if (code !== 0) {
-              const error = new errors.ErrorPolykeyCLISubprocessFailure(
+              const error = new errors.ErrorPolykeyCLIChildProcessFailure(
                 `Editor exited with code ${code}`,
               );
               reject(error);

--- a/src/secrets/CommandEnv.ts
+++ b/src/secrets/CommandEnv.ts
@@ -2,6 +2,7 @@ import type PolykeyClient from 'polykey/dist/PolykeyClient';
 import type { ParsedSecretPathValue } from '../types';
 import path from 'path';
 import os from 'os';
+import commander from 'commander';
 import * as utils from 'polykey/dist/utils';
 import CommandPolykey from '../CommandPolykey';
 import * as binProcessors from '../utils/processors';
@@ -26,297 +27,324 @@ class CommandEnv extends CommandPolykey {
     this.addOption(binOptions.preserveNewline);
     this.argument(
       '<args...>',
-      'command and arguments formatted as <envPaths...> -- [ cmd [cmdArgs...]]',
-      binParsers.parseEnvArgs,
+      'command and arguments formatted as <envPaths...> [-- cmd [cmdArgs...]]',
     );
-    this.action(
-      async (args: [Array<ParsedSecretPathValue>, Array<string>], options) => {
-        const { default: PolykeyClient } = await import(
-          'polykey/dist/PolykeyClient'
-        );
-        const {
-          envInvalid,
-          envDuplicate,
-          envFormat,
-        }: {
-          envInvalid: 'error' | 'warn' | 'ignore';
-          envDuplicate: 'keep' | 'overwrite' | 'warn' | 'error';
-          envFormat: 'auto' | 'unix' | 'cmd' | 'powershell' | 'json';
-        } = options;
-        // Populate a set with all the paths we want to preserve newlines for
-        const preservedSecrets = new Set<string>();
-        for (const [vaultName, secretPath] of options.preserveNewline) {
-          // The vault name is guaranteed to have a value.
-          // If a secret path is undefined, then the newline preservation was
-          // targeting the secrets of the entire vault. Otherwise, the target
-          // was a single secret.
-          if (secretPath == null) preservedSecrets.add(vaultName);
-          else preservedSecrets.add(`${vaultName}:${secretPath}`);
+    this.action(async (args, options) => {
+      const { default: PolykeyClient } = await import(
+        'polykey/dist/PolykeyClient'
+      );
+      const {
+        envInvalid,
+        envDuplicate,
+        envFormat,
+      }: {
+        envInvalid: 'error' | 'warn' | 'ignore';
+        envDuplicate: 'keep' | 'overwrite' | 'warn' | 'error';
+        envFormat: 'auto' | 'unix' | 'cmd' | 'powershell' | 'json';
+      } = options;
+      // Populate a set with all the paths we want to preserve newlines for
+      const preservedSecrets = new Set<string>();
+      for (const [vaultName, secretPath] of options.preserveNewline) {
+        // The vault name is guaranteed to have a value.
+        // If a secret path is undefined, then the newline preservation was
+        // targeting the secrets of the entire vault. Otherwise, the target
+        // was a single secret.
+        if (secretPath == null) preservedSecrets.add(vaultName);
+        else preservedSecrets.add(`${vaultName}:${secretPath}`);
+      }
+      // There are a few stages here
+      // 1. parse the desired secrets
+      // 2. obtain the desired secrets
+      // 3. switching behaviour here based on parameters
+      //   a. exec the command with the provided env variables from the secrets
+      //   b. output the env variables in the desired format
+
+      // Emulate commander's parsing to allow for parsing --
+      const fullArgs = process.argv;
+      const fullSeparatorIndex = fullArgs.indexOf('--');
+      const envVariables: Array<ParsedSecretPathValue> = [];
+      let cmd: string | undefined;
+      let argv: Array<string> = [];
+      if (fullSeparatorIndex === -1) {
+        // If the separator exists, then treat all args as environment paths
+        for (const arg of args) {
+          envVariables.push(binParsers.parseSecretPathEnv(arg));
         }
-        // There are a few stages here
-        // 1. parse the desired secrets
-        // 2. obtain the desired secrets
-        // 3. switching behaviour here based on parameters
-        //   a. exec the command with the provided env variables from the secrets
-        //   b. output the env variables in the desired format
-        const [envVariables, [cmd, ...argv]] = args;
-        const clientOptions = await binProcessors.processClientOptions(
-          options.nodePath,
-          options.nodeId,
-          options.clientHost,
-          options.clientPort,
-          this.fs,
-          this.logger.getChild(binProcessors.processClientOptions.name),
+      } else {
+        // Otherwise, separate command from environment paths
+        const afterSeparatorCount = fullArgs.length - fullSeparatorIndex - 1;
+        const cmdIndex = args.length - afterSeparatorCount;
+        const rawEnvVariables = args.slice(0, -afterSeparatorCount);
+        // Parse environment variables correctly
+        for (const arg of rawEnvVariables) {
+          envVariables.push(binParsers.parseSecretPathEnv(arg));
+        }
+        cmd = args[cmdIndex];
+        argv = args.slice(cmdIndex + 1);
+      }
+      if (envVariables.length === 0) {
+        this.addHelpText('before', 'You must provide at least 1 secret path');
+        this.outputHelp();
+        throw new commander.InvalidArgumentError(
+          'You must provide at least 1 secret path',
         );
-        const meta = await binProcessors.processAuthentication(
-          options.passwordFile,
-          this.fs,
-        );
+      }
+      const clientOptions = await binProcessors.processClientOptions(
+        options.nodePath,
+        options.nodeId,
+        options.clientHost,
+        options.clientPort,
+        this.fs,
+        this.logger.getChild(binProcessors.processClientOptions.name),
+      );
+      const meta = await binProcessors.processAuthentication(
+        options.passwordFile,
+        this.fs,
+      );
 
-        let pkClient: PolykeyClient;
-        this.exitHandlers.handlers.push(async () => {
-          if (pkClient != null) await pkClient.stop();
+      let pkClient: PolykeyClient;
+      this.exitHandlers.handlers.push(async () => {
+        if (pkClient != null) await pkClient.stop();
+      });
+      try {
+        pkClient = await PolykeyClient.createPolykeyClient({
+          nodeId: clientOptions.nodeId,
+          host: clientOptions.clientHost,
+          port: clientOptions.clientPort,
+          options: {
+            nodePath: options.nodePath,
+          },
+          logger: this.logger.getChild(PolykeyClient.name),
         });
-        try {
-          pkClient = await PolykeyClient.createPolykeyClient({
-            nodeId: clientOptions.nodeId,
-            host: clientOptions.clientHost,
-            port: clientOptions.clientPort,
-            options: {
-              nodePath: options.nodePath,
-            },
-            logger: this.logger.getChild(PolykeyClient.name),
-          });
 
-          // Getting envs
-          const [envp] = await binUtils.retryAuthentication(async (auth) => {
-            const responseStream =
-              await pkClient.rpcClient.methods.vaultsSecretsEnv();
-            // Writing desired secrets
-            const secretRenameMap = new Map<string, string | undefined>();
-            const writeP = (async () => {
-              const writer = responseStream.writable.getWriter();
-              let first = true;
-              for (const envVariable of envVariables) {
-                const [nameOrId, secretName, secretNameNew] = envVariable;
-                secretRenameMap.set(secretName ?? '/', secretNameNew);
-                await writer.write({
-                  nameOrId: nameOrId,
-                  secretName: secretName ?? '/',
-                  metadata: first ? auth : undefined,
-                });
-                first = false;
-              }
-              await writer.close();
-            })();
+        // Getting envs
+        const [envp] = await binUtils.retryAuthentication(async (auth) => {
+          const responseStream =
+            await pkClient.rpcClient.methods.vaultsSecretsEnv();
+          // Writing desired secrets
+          const secretRenameMap = new Map<string, string | undefined>();
+          const writeP = (async () => {
+            const writer = responseStream.writable.getWriter();
+            let first = true;
+            for (const envVariable of envVariables) {
+              const [nameOrId, secretName, secretNameNew] = envVariable;
+              secretRenameMap.set(secretName ?? '/', secretNameNew);
+              await writer.write({
+                nameOrId: nameOrId,
+                secretName: secretName ?? '/',
+                metadata: first ? auth : undefined,
+              });
+              first = false;
+            }
+            await writer.close();
+          })();
 
-            const envp: Record<string, string> = {};
-            const envpPath: Record<
-              string,
-              {
-                nameOrId: string;
-                secretName: string;
-              }
-            > = {};
-            for await (const value of responseStream.readable) {
-              const { nameOrId, secretName, secretContent } = value;
-              let newName = secretRenameMap.get(secretName);
-              if (newName == null) {
-                const secretEnvName = path.basename(secretName);
-                // Validating name
-                if (!binUtils.validEnvRegex.test(secretEnvName)) {
-                  switch (envInvalid) {
-                    case 'error':
-                      throw new binErrors.ErrorPolykeyCLIInvalidEnvName(
-                        `The following env variable name (${secretEnvName}) is invalid`,
-                      );
-                    case 'warn':
-                      this.logger.warn(
-                        `The following env variable name (${secretEnvName}) is invalid and was dropped`,
-                      );
-                    // Fallthrough
-                    case 'ignore':
-                      continue;
-                    default:
-                      utils.never();
-                  }
-                }
-                newName = secretEnvName;
-              }
-              // Handling duplicate names
-              if (envp[newName] != null) {
-                switch (envDuplicate) {
-                  // Continue without modifying
+          const envp: Record<string, string> = {};
+          const envpPath: Record<
+            string,
+            {
+              nameOrId: string;
+              secretName: string;
+            }
+          > = {};
+          for await (const value of responseStream.readable) {
+            const { nameOrId, secretName, secretContent } = value;
+            let newName = secretRenameMap.get(secretName);
+            if (newName == null) {
+              const secretEnvName = path.basename(secretName);
+              // Validating name
+              if (!binUtils.validEnvRegex.test(secretEnvName)) {
+                switch (envInvalid) {
                   case 'error':
-                    throw new binErrors.ErrorPolykeyCLIDuplicateEnvName(
-                      `The env variable (${newName}) is duplicate`,
+                    throw new binErrors.ErrorPolykeyCLIInvalidEnvName(
+                      `The following env variable name (${secretEnvName}) is invalid`,
                     );
-                  // Fallthrough
-                  case 'keep':
-                    continue;
-                  // Log a warning and overwrite
                   case 'warn':
                     this.logger.warn(
-                      `The env variable (${newName}) is duplicate, overwriting`,
+                      `The following env variable name (${secretEnvName}) is invalid and was dropped`,
                     );
                   // Fallthrough
-                  case 'overwrite':
-                    break;
+                  case 'ignore':
+                    continue;
                   default:
                     utils.never();
                 }
               }
-
-              // Find if we need to preserve the newline for this secret
-              let preserveNewline = false;
-              // If only the vault name is specified to be preserved, then
-              // preserve the newlines of all secrets inside the vault.
-              // Otherwise, if a full secret path has been specified, then
-              // preserve that secret path.
-              if (
-                preservedSecrets.has(nameOrId) ||
-                preservedSecrets.has(`${nameOrId}:${newName}`)
-              ) {
-                preserveNewline = true;
-              }
-
-              // Trim the single trailing newline if it exists
-              if (!preserveNewline && secretContent.endsWith('\n')) {
-                envp[newName] = secretContent.slice(0, -1);
-              } else {
-                envp[newName] = secretContent;
-              }
-              envpPath[newName] = {
-                nameOrId,
-                secretName,
-              };
+              newName = secretEnvName;
             }
-            await writeP;
-            return [envp, envpPath];
-          }, meta);
-          // End connection early to avoid errors on server
-          await pkClient.stop();
-
-          // Here we want to switch between the different usages
-          const platform = os.platform();
-          if (cmd != null) {
-            // If a cmd is provided then we default to exec it
-            switch (platform) {
-              case 'linux': // Fallthrough
-              case 'darwin':
-                {
-                  const { exec } = await import('@matrixai/exec');
-                  try {
-                    exec.execvp(cmd, argv, envp);
-                  } catch (e) {
-                    if ('code' in e && e.code === 'GenericFailure') {
-                      throw new binErrors.ErrorPolykeyCLISubprocessFailure(
-                        `Command failed with error ${e}`,
-                        {
-                          cause: e,
-                          data: { command: [cmd, ...argv] },
-                        },
-                      );
-                    }
-                    throw e;
-                  }
-                }
-                break;
-              default: {
-                const { spawnSync } = await import('child_process');
-                const result = spawnSync(cmd, argv, {
-                  env: {
-                    ...process.env,
-                    ...envp,
-                  },
-                  shell: false,
-                  windowsHide: true,
-                  stdio: 'inherit',
-                });
-                process.exit(result.status ?? 255);
+            // Handling duplicate names
+            if (envp[newName] != null) {
+              switch (envDuplicate) {
+                // Continue without modifying
+                case 'error':
+                  throw new binErrors.ErrorPolykeyCLIDuplicateEnvName(
+                    `The env variable (${newName}) is duplicate`,
+                  );
+                // Fallthrough
+                case 'keep':
+                  continue;
+                // Log a warning and overwrite
+                case 'warn':
+                  this.logger.warn(
+                    `The env variable (${newName}) is duplicate, overwriting`,
+                  );
+                // Fallthrough
+                case 'overwrite':
+                  break;
+                default:
+                  utils.never();
               }
             }
-          } else {
-            // Otherwise we switch between output formats
-            // If set to `auto` then we need to infer the format
-            let format = envFormat;
-            if (envFormat === 'auto') {
-              format =
-                {
-                  darwin: 'unix',
-                  linux: 'unix',
-                  win32: 'cmd',
-                }[platform] ?? 'unix';
+
+            // Find if we need to preserve the newline for this secret
+            let preserveNewline = false;
+            // If only the vault name is specified to be preserved, then
+            // preserve the newlines of all secrets inside the vault.
+            // Otherwise, if a full secret path has been specified, then
+            // preserve that secret path.
+            if (
+              preservedSecrets.has(nameOrId) ||
+              preservedSecrets.has(`${nameOrId}:${newName}`)
+            ) {
+              preserveNewline = true;
             }
-            switch (format) {
-              case 'unix':
-                {
-                  // Formatting as a .env file
-                  let data = '';
-                  for (const [key, value] of Object.entries(envp)) {
-                    data += `${key}='${value}'\n`;
+
+            // Trim the single trailing newline if it exists
+            if (!preserveNewline && secretContent.endsWith('\n')) {
+              envp[newName] = secretContent.slice(0, -1);
+            } else {
+              envp[newName] = secretContent;
+            }
+            envpPath[newName] = {
+              nameOrId,
+              secretName,
+            };
+          }
+          await writeP;
+          return [envp, envpPath];
+        }, meta);
+        // End connection early to avoid errors on server
+        await pkClient.stop();
+
+        // Here we want to switch between the different usages
+        const platform = os.platform();
+        if (cmd != null) {
+          // If a cmd is provided then we default to exec it
+          switch (platform) {
+            case 'linux': // Fallthrough
+            case 'darwin':
+              {
+                const { exec } = await import('@matrixai/exec');
+                try {
+                  exec.execvp(cmd, argv, envp);
+                } catch (e) {
+                  if ('code' in e && e.code === 'GenericFailure') {
+                    throw new binErrors.ErrorPolykeyCLIChildProcessFailure(
+                      `Command failed with error ${e}`,
+                      {
+                        cause: e,
+                        data: { command: [cmd, ...argv] },
+                      },
+                    );
                   }
-                  process.stdout.write(
-                    binUtils.outputFormatter({
-                      type: 'raw',
-                      data,
-                    }),
-                  );
+                  throw e;
                 }
-                break;
-              case 'cmd':
-                {
-                  // Formatting as a .bat file for windows cmd
-                  let data = '';
-                  for (const [key, value] of Object.entries(envp)) {
-                    data += `set "${key}=${value}"\n`;
-                  }
-                  process.stdout.write(
-                    binUtils.outputFormatter({
-                      type: 'raw',
-                      data,
-                    }),
-                  );
-                }
-                break;
-              case 'powershell':
-                {
-                  // Formatting as a .bat file for windows cmd
-                  let data = '';
-                  for (const [key, value] of Object.entries(envp)) {
-                    data += `\$env:${key} = '${value}'\n`;
-                  }
-                  process.stdout.write(
-                    binUtils.outputFormatter({
-                      type: 'raw',
-                      data,
-                    }),
-                  );
-                }
-                break;
-              case 'json':
-                {
-                  const data = {};
-                  for (const [key, value] of Object.entries(envp)) {
-                    data[key] = value;
-                  }
-                  process.stdout.write(
-                    binUtils.outputFormatter({
-                      type: 'json',
-                      data: data,
-                    }),
-                  );
-                }
-                break;
-              default:
-                utils.never();
+              }
+              break;
+            default: {
+              const { spawnSync } = await import('child_process');
+              const result = spawnSync(cmd, argv, {
+                env: {
+                  ...process.env,
+                  ...envp,
+                },
+                shell: false,
+                windowsHide: true,
+                stdio: 'inherit',
+              });
+              process.exit(result.status ?? 255);
             }
           }
-        } finally {
-          if (pkClient! != null) await pkClient.stop();
+        } else {
+          // Otherwise we switch between output formats
+          // If set to `auto` then we need to infer the format
+          let format = envFormat;
+          if (envFormat === 'auto') {
+            format =
+              {
+                darwin: 'unix',
+                linux: 'unix',
+                win32: 'cmd',
+              }[platform] ?? 'unix';
+          }
+          switch (format) {
+            case 'unix':
+              {
+                // Formatting as a .env file
+                let data = '';
+                for (const [key, value] of Object.entries(envp)) {
+                  data += `${key}='${value}'\n`;
+                }
+                process.stdout.write(
+                  binUtils.outputFormatter({
+                    type: 'raw',
+                    data,
+                  }),
+                );
+              }
+              break;
+            case 'cmd':
+              {
+                // Formatting as a .bat file for windows cmd
+                let data = '';
+                for (const [key, value] of Object.entries(envp)) {
+                  data += `set "${key}=${value}"\n`;
+                }
+                process.stdout.write(
+                  binUtils.outputFormatter({
+                    type: 'raw',
+                    data,
+                  }),
+                );
+              }
+              break;
+            case 'powershell':
+              {
+                // Formatting as a .bat file for windows cmd
+                let data = '';
+                for (const [key, value] of Object.entries(envp)) {
+                  data += `\$env:${key} = '${value}'\n`;
+                }
+                process.stdout.write(
+                  binUtils.outputFormatter({
+                    type: 'raw',
+                    data,
+                  }),
+                );
+              }
+              break;
+            case 'json':
+              {
+                const data = {};
+                for (const [key, value] of Object.entries(envp)) {
+                  data[key] = value;
+                }
+                process.stdout.write(
+                  binUtils.outputFormatter({
+                    type: 'json',
+                    data: data,
+                  }),
+                );
+              }
+              break;
+            default:
+              utils.never();
+          }
         }
-      },
-    );
+      } finally {
+        if (pkClient! != null) await pkClient.stop();
+      }
+    });
   }
 }
 

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -319,7 +319,7 @@ const parents = new commander.Option(
 ).default(false);
 
 const preserveNewline = new commander.Option(
-  '-pn --preserve-newline <path>',
+  '--preserve-newline <path>',
   'Preserve the last trailing newline for the secret content',
 )
   .argParser((value: string, previous: Array<[string, string?, string?]>) => {

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -196,38 +196,6 @@ const parsePort: (data: string) => Port = validateParserToArgParser(
 const parseSeedNodes: (data: string) => [SeedNodes, boolean] =
   validateParserToArgParser(nodesUtils.parseSeedNodes);
 
-/**
- * This parses the arguments used for the env command. It should be formatted as
- * <secretPath...> [-- cmd [cmdArgs...]]
- * The cmd part of the list is separated by using `--`.
- */
-function parseEnvArgs(
-  value: string,
-  prev: [Array<ParsedSecretPathValue>, Array<string>, boolean] | undefined,
-): [Array<ParsedSecretPathValue>, Array<string>, boolean] {
-  const current: [Array<ParsedSecretPathValue>, Array<string>, boolean] =
-    prev ?? [[], [], false];
-  const [secretsList, commandList, parsingCommandCurrent] = current;
-  let parsingCommand = parsingCommandCurrent;
-  if (!parsingCommand) {
-    // Parse a secret path
-    if (value !== '--') {
-      secretsList.push(parseSecretPathEnv(value));
-    } else {
-      parsingCommand = true;
-    }
-  } else {
-    // Otherwise we just have the cmd args
-    commandList.push(value);
-  }
-  if (secretsList.length === 0 && commandList.length > 0) {
-    throw new commander.InvalidArgumentError(
-      'You must provide at least 1 secret path',
-    );
-  }
-  return [secretsList, commandList, parsingCommand];
-}
-
 export {
   vaultNameRegex,
   secretPathRegex,
@@ -256,5 +224,4 @@ export {
   parseProviderId,
   parseIdentityId,
   parseProviderIdList,
-  parseEnvArgs,
 };

--- a/tests/secrets/env.test.ts
+++ b/tests/secrets/env.test.ts
@@ -1,5 +1,4 @@
 import type { VaultName } from 'polykey/dist/vaults/types';
-import type { ParsedSecretPathValue } from '@/types';
 import path from 'path';
 import fs from 'fs';
 import fc from 'fast-check';
@@ -9,7 +8,6 @@ import PolykeyAgent from 'polykey/dist/PolykeyAgent';
 import { vaultOps } from 'polykey/dist/vaults';
 import * as keysUtils from 'polykey/dist/keys/utils';
 import { sysexits } from 'polykey/dist/utils';
-import * as binParsers from '@/utils/parsers';
 import * as testUtils from '../utils';
 
 describe('commandEnv', () => {
@@ -62,7 +60,6 @@ describe('commandEnv', () => {
       'unix',
       `${vaultName}:SECRET`,
       '--',
-      '--',
       'node',
       '-e',
       'console.log(JSON.stringify(process.env))',
@@ -89,7 +86,6 @@ describe('commandEnv', () => {
       'unix',
       `${vaultName}:SECRET1`,
       `${vaultName}:SECRET2`,
-      '--',
       '--',
       'node',
       '-e',
@@ -120,7 +116,6 @@ describe('commandEnv', () => {
       'unix',
       `${vaultName}:dir1`,
       '--',
-      '--',
       'node',
       '-e',
       'console.log(JSON.stringify(process.env))',
@@ -147,7 +142,6 @@ describe('commandEnv', () => {
       '--env-format',
       'unix',
       `${vaultName}:SECRET=SECRET_NEW`,
-      '--',
       '--',
       'node',
       '-e',
@@ -176,7 +170,6 @@ describe('commandEnv', () => {
       '--env-format',
       'unix',
       `${vaultName}:dir1=SECRET_NEW`,
-      '--',
       '--',
       'node',
       '-e',
@@ -211,7 +204,6 @@ describe('commandEnv', () => {
       `${vaultName}:SECRET2`,
       `${vaultName}:dir1`,
       '--',
-      '--',
       'node',
       '-e',
       'console.log(JSON.stringify(process.env))',
@@ -239,7 +231,6 @@ describe('commandEnv', () => {
       '--env-format',
       'unix',
       `${vaultName}:SECRET1`,
-      '--',
       '--',
       'node',
       '-e',
@@ -276,7 +267,6 @@ describe('commandEnv', () => {
       `${vaultName}:SECRET2=SECRET1`,
       `${vaultName}:SECRET3=SECRET4`,
       `${vaultName}:dir1`,
-      '--',
       '--',
       'node',
       '-e',
@@ -695,7 +685,6 @@ describe('commandEnv', () => {
       'unix',
       `${vaultName}:${secretName}`,
       '--',
-      '--',
       'node',
       '-e',
       'console.log(JSON.stringify(process.env))',
@@ -725,7 +714,6 @@ describe('commandEnv', () => {
         '--env-format',
         'unix',
         `${vaultName}:${secretName}`,
-        '--',
         '--',
         'node',
         '-e',
@@ -760,7 +748,6 @@ describe('commandEnv', () => {
         '--preserve-newline',
         `${vaultName}:${secretName}`,
         `${vaultName}:${secretName}`,
-        '--',
         '--',
         'node',
         '-e',
@@ -798,7 +785,6 @@ describe('commandEnv', () => {
       `${vaultName}`,
       '--preserve-newline',
       `${vaultName}:${secretName1}`,
-      '--',
       '--',
       'node',
       '-e',
@@ -838,7 +824,6 @@ describe('commandEnv', () => {
       '--preserve-newline',
       `${vaultName}`,
       '--',
-      '--',
       'node',
       '-e',
       'console.log(JSON.stringify(process.env))',
@@ -865,7 +850,6 @@ describe('commandEnv', () => {
       '--preserve-newline',
       `${vaultName}`,
       '--',
-      '--',
       'node',
       '-e',
       'console.log(JSON.stringify(process.env))',
@@ -879,35 +863,6 @@ describe('commandEnv', () => {
     expect(jsonOut2[secretName2]).toBe(secretContent2);
     expect(jsonOut2[secretName3]).toBe(secretContent3);
   });
-  test.prop([
-    testUtils.secretPathEnvArrayArb,
-    fc.string().noShrink(),
-    testUtils.cmdArgsArrayArb,
-  ])(
-    'parse secrets env arguments',
-    async (secretPathEnvArray, cmd, cmdArgsArray) => {
-      let output:
-        | [Array<ParsedSecretPathValue>, Array<string>, boolean]
-        | undefined = undefined;
-      // By running the parser directly, we are bypassing commander, so it works
-      // with a single --
-      const args: Array<string> = [
-        ...secretPathEnvArray,
-        '--',
-        cmd,
-        ...cmdArgsArray,
-      ];
-      for (const arg of args) {
-        output = binParsers.parseEnvArgs(arg, output);
-      }
-      const [parsedEnvs, parsedArgs] = output!;
-      const expectedSecretPathArray = secretPathEnvArray.map((v) => {
-        return binParsers.parseSecretPath(v);
-      });
-      expect(parsedEnvs).toMatchObject(expectedSecretPathArray);
-      expect(parsedArgs).toMatchObject([cmd, ...cmdArgsArray]);
-    },
-  );
   test('handles no arguments', async () => {
     const command = ['secrets', 'env', '-np', dataDir, '--env-format', 'unix'];
     const result = await testUtils.pkExec(command, {


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->

Previously, we needed to use two `--` to separate commands from arguments. Now, that is no longer needed, and we can use a single `--` to parse arguments.

`polykey secrets env vault:SECRET -- cmd arg1 arg2`

Note that you still can't do this, as it would be parsed by the shell instead of the actual command.

```
$ polykey secrets env vault:SECRET -- cmd arg1 arg2 && cmd2
'cmd' run by polykey
'cmd2' run by shell
```

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #325 (FIX ENG-466)

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Move parsing to action and emulate what it does
- [x] 2. Remove old parser
- [x] 3. Update tests

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
