### PR TITLE
feat: added export option to secrets env #342

### DIFF
--- a/src/secrets/CommandEnv.ts
+++ b/src/secrets/CommandEnv.ts
@@ -24,6 +24,7 @@ class CommandEnv extends CommandPolykey {
     this.addOption(binOptions.envFormat);
     this.addOption(binOptions.envInvalid);
     this.addOption(binOptions.envDuplicate);
+    this.addOption(binOptions.envExport);
     this.addOption(binOptions.preserveNewline);
     this.argument(
       '<args...>',
@@ -280,22 +281,24 @@ class CommandEnv extends CommandPolykey {
           switch (format) {
             case 'unix':
               {
-                // Formatting as a .env file
                 let data = '';
                 for (const [key, value] of Object.entries(envp)) {
-                  data += `${key}='${value}'\n`;
+                  if (options.envExport) {
+                    data += `export ${key}='${value}'\n`;
+                  } else {
+                    data += `${key}='${value}'\n`;
+                  }
                 }
                 process.stdout.write(
                   binUtils.outputFormatter({
                     type: 'raw',
-                    data,
+                    data: data,
                   }),
                 );
               }
               break;
             case 'cmd':
               {
-                // Formatting as a .bat file for windows cmd
                 let data = '';
                 for (const [key, value] of Object.entries(envp)) {
                   data += `set "${key}=${value}"\n`;
@@ -303,22 +306,25 @@ class CommandEnv extends CommandPolykey {
                 process.stdout.write(
                   binUtils.outputFormatter({
                     type: 'raw',
-                    data,
+                    data: data,
                   }),
                 );
               }
               break;
             case 'powershell':
               {
-                // Formatting as a .bat file for windows cmd
                 let data = '';
                 for (const [key, value] of Object.entries(envp)) {
-                  data += `\$env:${key} = '${value}'\n`;
+                  if (options.envExport) {
+                    data += `$env:${key} = '${value}'\n`;
+                  } else {
+                    data += `$${key} = '${value}'\n`;
+                  }
                 }
                 process.stdout.write(
                   binUtils.outputFormatter({
                     type: 'raw',
-                    data,
+                    data: data,
                   }),
                 );
               }

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -246,6 +246,11 @@ const envDuplicate = new commander.Option(
   .choices(['keep', 'overwrite', 'warn', 'error'])
   .default('overwrite');
 
+const envExport = new commander.Option(
+  '-ee --env-export',
+  'If enabled, exports the set environment variables to child environments',
+).default(false);
+
 const discoveryMonitor = new commander.Option(
   '--monitor',
   'Enabling monitoring will cause discover to output discovery events as they happen and will exit once all children are processed',
@@ -363,6 +368,7 @@ export {
   envFormat,
   envInvalid,
   envDuplicate,
+  envExport,
   discoveryMonitor,
   seekStart,
   seekEnd,


### PR DESCRIPTION
### Description
I have introduced an export flag in options.ts to determine whether the export keyword should be prefixed to environment variables for shell usage. This is relevant for Unix-based systems, where export is required to make the variables available to child processes. On Windows, however, the export keyword or an equivalent is unnecessary because a child process automatically inherits the environment variables of its parent process. This behavior is documented on the official Microsoft website: [Environment Variables](https://learn.microsoft.com/en-us/windows/win32/procthread/environment-variables).

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #342

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Add export option for json
- [x] 2. Add Tests

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
