### PR TITLE
Allow fully qualified paths for new secret name in secrets rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dist
 # editor
 .vscode/
 .idea/
+
+# prettier for editor formatting
+.prettierrc

--- a/src/secrets/CommandRename.ts
+++ b/src/secrets/CommandRename.ts
@@ -16,29 +16,32 @@ class CommandRename extends CommandPolykey {
       'Path to where the secret to be renamed, specified as <vaultName>:<directoryPath>',
       binParsers.parseSecretPath,
     );
-    this.argument('<newSecretName>', 'New name of the secret');
+    this.argument(
+      '<newSecretName>',
+      'Fully-qualified new name for the secret, specified as <vaultName>:<secretPath>',
+      binParsers.parseSecretPath,
+    );
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
-    this.action(async (secretPath, newSecretNameArg, options) => {
-      // Ensure that a valid secret path is provided
-      if (
-        secretPath[1] == null ||
-        secretPath[1].trim() === '' ||
-        secretPath[1].trim() === '/'
-      ) {
+    this.action(async (secretPath, newSecretPath, options) => {
+      // Rename operation cannot work across vaults, only within a vault
+      if (secretPath[0] !== newSecretPath[0]) {
         throw new errors.ErrorPolykeyCLIRenameSecret(
-          'EPERM: Cannot rename vault root',
+          'Cannot rename file into another vault',
         );
       }
-
-      // Process the newSecretNameArg using the abstracted helper method.
-      // secretPath[0] is the original vault name.
-      const finalNewSecretName = CommandRename._processNewSecretNameArgument(
-        newSecretNameArg,
-        secretPath[0],
-      );
-
+      // Ensure that a valid secret path is provided
+      if (secretPath[1] == null) {
+        throw new errors.ErrorPolykeyCLIRenameSecret(
+          'Cannot rename vault root',
+        );
+      }
+      if (newSecretPath[1] == null) {
+        throw new errors.ErrorPolykeyCLIRenameSecret(
+          'Cannot rename to vault root',
+        );
+      }
       const { default: PolykeyClient } = await import(
         'polykey/PolykeyClient.js'
       );
@@ -75,7 +78,7 @@ class CommandRename extends CommandPolykey {
               metadata: auth,
               nameOrId: secretPath[0],
               secretName: secretPath[1],
-              newSecretName: finalNewSecretName,
+              newSecretName: newSecretPath[1],
             }),
           meta,
         );
@@ -83,67 +86,6 @@ class CommandRename extends CommandPolykey {
         if (pkClient! != null) await pkClient.stop();
       }
     });
-  }
-
-  /**
-   * Processes the newSecretName argument to ensure it's a valid base name.
-   */
-  private static _processNewSecretNameArgument(
-    newSecretNameArg: string,
-    originalVaultName: string,
-  ): string {
-    let finalNewBaseName = newSecretNameArg;
-
-    if (newSecretNameArg.includes(':')) {
-      let parsedNewPath: Array<any>;
-      try {
-        parsedNewPath = binParsers.parseSecretPath(newSecretNameArg);
-      } catch (e: any) {
-        throw new errors.ErrorPolykeyCLIRenameSecret(
-          `EINVALID: The new secret name '${newSecretNameArg}' appears to be a path but could not be parsed: ${e.message}`,
-        );
-      }
-      const newVaultNameInArg: string = parsedNewPath[0];
-      const newSecretPathPart: string = parsedNewPath[1];
-      if (newVaultNameInArg !== originalVaultName) {
-        throw new errors.ErrorPolykeyCLIRenameSecret(
-          `ECROSSVAULT: Renaming to a different vault ('${newVaultNameInArg}') is not supported by this command. The target vault must be the same as the source vault ('${originalVaultName}').`,
-        );
-      }
-      if (
-        newSecretPathPart == null ||
-        newSecretPathPart.trim() === '' ||
-        newSecretPathPart.trim() === '/'
-      ) {
-        throw new errors.ErrorPolykeyCLIRenameSecret(
-          `EINVALID: The path component of the new secret name '${newSecretNameArg}' is empty or invalid.`,
-        );
-      }
-      const parts = newSecretPathPart.split('/').filter((p) => p.length > 0);
-      if (parts.length === 0) {
-        throw new errors.ErrorPolykeyCLIRenameSecret(
-          `EINVALID: Could not extract a valid base name from the path component '${newSecretPathPart}' in '${newSecretNameArg}'.`,
-        );
-      }
-      finalNewBaseName = parts[parts.length - 1];
-    } else {
-      if (newSecretNameArg.includes('/')) {
-        throw new errors.ErrorPolykeyCLIRenameSecret(
-          `EINVALIDNAME: The new secret name '${newSecretNameArg}' must be a base name and cannot contain '/'. If you intended to specify a path, include the vault name (e.g., '${originalVaultName}:/path/NewName').`,
-        );
-      }
-    }
-    if (!finalNewBaseName || finalNewBaseName.trim() === '') {
-      throw new errors.ErrorPolykeyCLIRenameSecret(
-        `EEMPTYNAME: The new secret name derived from '${newSecretNameArg}' is empty.`,
-      );
-    }
-    if (finalNewBaseName.includes('/') || finalNewBaseName.includes(':')) {
-      throw new errors.ErrorPolykeyCLIRenameSecret(
-        `EINVALIDCHAR: The final new secret name '${finalNewBaseName}' (derived from '${newSecretNameArg}') is invalid. It cannot contain '/' or ':' characters.`,
-      );
-    }
-    return finalNewBaseName;
   }
 }
 

--- a/src/secrets/CommandRename.ts
+++ b/src/secrets/CommandRename.ts
@@ -75,7 +75,7 @@ class CommandRename extends CommandPolykey {
               metadata: auth,
               nameOrId: secretPath[0],
               secretName: secretPath[1],
-              newSecretName: newSecretNameArg,
+              newSecretName: finalNewSecretName,
             }),
           meta,
         );

--- a/src/secrets/CommandRename.ts
+++ b/src/secrets/CommandRename.ts
@@ -103,8 +103,8 @@ class CommandRename extends CommandPolykey {
           `EINVALID: The new secret name '${newSecretNameArg}' appears to be a path but could not be parsed: ${e.message}`,
         );
       }
-      const newVaultNameInArg = parsedNewPath[0];
-      const newSecretPathPart = parsedNewPath[1];
+      const newVaultNameInArg: string = parsedNewPath[0];
+      const newSecretPathPart: string = parsedNewPath[1];
       if (newVaultNameInArg !== originalVaultName) {
         throw new errors.ErrorPolykeyCLIRenameSecret(
           `ECROSSVAULT: Renaming to a different vault ('${newVaultNameInArg}') is not supported by this command. The target vault must be the same as the source vault ('${originalVaultName}').`,

--- a/src/secrets/CommandRename.ts
+++ b/src/secrets/CommandRename.ts
@@ -20,13 +20,25 @@ class CommandRename extends CommandPolykey {
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
-    this.action(async (secretPath, newSecretName, options) => {
+    this.action(async (secretPath, newSecretNameArg, options) => {
       // Ensure that a valid secret path is provided
-      if (secretPath[1] == null) {
+      if (
+        secretPath[1] == null ||
+        secretPath[1].trim() === '' ||
+        secretPath[1].trim() === '/'
+      ) {
         throw new errors.ErrorPolykeyCLIRenameSecret(
           'EPERM: Cannot rename vault root',
         );
       }
+
+      // Process the newSecretNameArg using the abstracted helper method.
+      // secretPath[0] is the original vault name.
+      const finalNewSecretName = CommandRename._processNewSecretNameArgument(
+        newSecretNameArg,
+        secretPath[0],
+      );
+
       const { default: PolykeyClient } = await import(
         'polykey/PolykeyClient.js'
       );
@@ -63,7 +75,7 @@ class CommandRename extends CommandPolykey {
               metadata: auth,
               nameOrId: secretPath[0],
               secretName: secretPath[1],
-              newSecretName: newSecretName,
+              newSecretName: newSecretNameArg,
             }),
           meta,
         );
@@ -71,6 +83,67 @@ class CommandRename extends CommandPolykey {
         if (pkClient! != null) await pkClient.stop();
       }
     });
+  }
+
+  /**
+   * Processes the newSecretName argument to ensure it's a valid base name.
+   */
+  private static _processNewSecretNameArgument(
+    newSecretNameArg: string,
+    originalVaultName: string,
+  ): string {
+    let finalNewBaseName = newSecretNameArg;
+
+    if (newSecretNameArg.includes(':')) {
+      let parsedNewPath: Array<any>;
+      try {
+        parsedNewPath = binParsers.parseSecretPath(newSecretNameArg);
+      } catch (e: any) {
+        throw new errors.ErrorPolykeyCLIRenameSecret(
+          `EINVALID: The new secret name '${newSecretNameArg}' appears to be a path but could not be parsed: ${e.message}`,
+        );
+      }
+      const newVaultNameInArg = parsedNewPath[0];
+      const newSecretPathPart = parsedNewPath[1];
+      if (newVaultNameInArg !== originalVaultName) {
+        throw new errors.ErrorPolykeyCLIRenameSecret(
+          `ECROSSVAULT: Renaming to a different vault ('${newVaultNameInArg}') is not supported by this command. The target vault must be the same as the source vault ('${originalVaultName}').`,
+        );
+      }
+      if (
+        newSecretPathPart == null ||
+        newSecretPathPart.trim() === '' ||
+        newSecretPathPart.trim() === '/'
+      ) {
+        throw new errors.ErrorPolykeyCLIRenameSecret(
+          `EINVALID: The path component of the new secret name '${newSecretNameArg}' is empty or invalid.`,
+        );
+      }
+      const parts = newSecretPathPart.split('/').filter((p) => p.length > 0);
+      if (parts.length === 0) {
+        throw new errors.ErrorPolykeyCLIRenameSecret(
+          `EINVALID: Could not extract a valid base name from the path component '${newSecretPathPart}' in '${newSecretNameArg}'.`,
+        );
+      }
+      finalNewBaseName = parts[parts.length - 1];
+    } else {
+      if (newSecretNameArg.includes('/')) {
+        throw new errors.ErrorPolykeyCLIRenameSecret(
+          `EINVALIDNAME: The new secret name '${newSecretNameArg}' must be a base name and cannot contain '/'. If you intended to specify a path, include the vault name (e.g., '${originalVaultName}:/path/NewName').`,
+        );
+      }
+    }
+    if (!finalNewBaseName || finalNewBaseName.trim() === '') {
+      throw new errors.ErrorPolykeyCLIRenameSecret(
+        `EEMPTYNAME: The new secret name derived from '${newSecretNameArg}' is empty.`,
+      );
+    }
+    if (finalNewBaseName.includes('/') || finalNewBaseName.includes(':')) {
+      throw new errors.ErrorPolykeyCLIRenameSecret(
+        `EINVALIDCHAR: The final new secret name '${finalNewBaseName}' (derived from '${newSecretNameArg}') is invalid. It cannot contain '/' or ':' characters.`,
+      );
+    }
+    return finalNewBaseName;
   }
 }
 

--- a/tests/secrets/rename.test.ts
+++ b/tests/secrets/rename.test.ts
@@ -33,6 +33,7 @@ describe('commandRenameSecret', () => {
       logger: logger,
     });
   });
+
   afterEach(async () => {
     await polykeyAgent.stop();
     await fs.promises.rm(dataDir, {
@@ -41,42 +42,106 @@ describe('commandRenameSecret', () => {
     });
   });
 
-  test('should rename secrets', async () => {
-    const vaultName = 'vault' as VaultName;
+  test('should rename secrets using a simple new name', async () => {
+    const vaultName = 'vaultSimpleRename' as VaultName;
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-    const secretName = 'secret';
-    const newSecretName = 'secret-renamed';
-    const secretContent = 'this is the secret';
+    const oldSecretName = 'secretOriginal';
+    const newSecretBaseName = 'secretNewBase'; // Changed variable name for clarity
+    const secretContent = 'this is the secret for simple rename';
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
-      await vaultOps.addSecret(vault, secretName, secretContent);
+      await vaultOps.addSecret(vault, oldSecretName, secretContent);
     });
     command = [
       'secrets',
       'rename',
       '-np',
       dataDir,
-      `${vaultName}:${secretName}`,
-      newSecretName,
+      `${vaultName}:${oldSecretName}`,
+      newSecretBaseName, // Use the simple base name
     ];
     const result = await testUtils.pkStdio(command, {
       env: { PK_PASSWORD: password },
       cwd: dataDir,
     });
     expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe(''); // Expect no errors
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
       const list = await vaultOps.listSecrets(vault);
-      expect(list.sort()).toStrictEqual([newSecretName]);
+      expect(list.sort()).toStrictEqual([newSecretBaseName]);
+      expect(list).not.toContain(oldSecretName);
     });
   });
-  test('should not rename vault root', async () => {
-    const vaultName = 'vault' as VaultName;
-    await polykeyAgent.vaultManager.createVault(vaultName);
-    command = ['secrets', 'rename', '-np', dataDir, vaultName, 'rename'];
+
+  // New test case for the fix
+  test('should rename secret when new name is a fully qualified path', async () => {
+    const vaultName = 'vaultFQRename' as VaultName; // Use a distinct vault name for the test
+    const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
+    const oldSecretName = 'oldSecretName';
+    const newSecretBaseName = 'newSecretNameByPath'; // The actual target base name
+    const secretContent = 'content for fully qualified path rename test';
+
+    // Add initial secret
+    await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
+      await vaultOps.addSecret(vault, oldSecretName, secretContent);
+    });
+
+    // Construct the fully qualified path for the new secret name
+    // This format matches the problematic case: VaultName:/NewName
+    const newSecretFullyQualified = `${vaultName}:/${newSecretBaseName}`;
+
+    command = [
+      'secrets',
+      'rename',
+      '-np',
+      dataDir,
+      `${vaultName}:${oldSecretName}`, // Source secret path
+      newSecretFullyQualified, // New secret name as fully qualified path
+    ];
+
     const result = await testUtils.pkStdio(command, {
+      env: { PK_PASSWORD: password },
+      cwd: dataDir,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe(''); // Expect no errors
+
+    // Verify the rename
+    await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
+      const secretsList = await vaultOps.listSecrets(vault);
+      expect(secretsList).toContain(newSecretBaseName); // Check for the base name
+      expect(secretsList).not.toContain(oldSecretName);
+      expect(secretsList.length).toBe(1); // Assuming only this secret is in the test vault
+    });
+  });
+
+  test('should not rename vault root', async () => {
+    const vaultName = 'vaultRootTest' as VaultName; // Use a distinct vault name
+    await polykeyAgent.vaultManager.createVault(vaultName);
+    // Attempting to rename the vault itself, or an empty path within it
+    command = [
+      'secrets',
+      'rename',
+      '-np',
+      dataDir,
+      `${vaultName}:/`,
+      'newNameForRoot',
+    ];
+    let result = await testUtils.pkStdio(command, {
       env: { PK_PASSWORD: password },
       cwd: dataDir,
     });
     expect(result.exitCode).not.toBe(0);
     expect(result.stderr).toInclude('EPERM');
+
+    // Original test for trying to rename the vault name directly (which parseSecretPath handles as [vaultName, undefined, undefined])
+    // The `CommandRename` checks secretPath[1] == null, which covers `vaultName` (no colon) for the first arg.
+    command = ['secrets', 'rename', '-np', dataDir, vaultName, 'rename'];
+    result = await testUtils.pkStdio(command, {
+      env: { PK_PASSWORD: password },
+      cwd: dataDir,
+    });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toInclude('EPERM'); // This is because secretPath[1] will be undefined
   });
 });

--- a/tests/secrets/rename.test.ts
+++ b/tests/secrets/rename.test.ts
@@ -12,7 +12,6 @@ describe('commandRenameSecret', () => {
   const logger = new Logger('CLI Test', LogLevel.WARN, [new StreamHandler()]);
   let dataDir: string;
   let polykeyAgent: PolykeyAgent;
-  let command: Array<string>;
 
   beforeEach(async () => {
     dataDir = await fs.promises.mkdtemp(
@@ -42,106 +41,89 @@ describe('commandRenameSecret', () => {
     });
   });
 
-  test('should rename secrets using a simple new name', async () => {
-    const vaultName = 'vaultSimpleRename' as VaultName;
+  test('should rename secrets', async () => {
+    const vaultName = 'vault' as VaultName;
     const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-    const oldSecretName = 'secretOriginal';
-    const newSecretBaseName = 'secretNewBase'; // Changed variable name for clarity
+    const oldSecretName = 'secretOld';
+    const newSecretName = 'secretNew';
     const secretContent = 'this is the secret for simple rename';
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
       await vaultOps.addSecret(vault, oldSecretName, secretContent);
     });
-    command = [
+
+    // Should fail if only new name is provided
+    const command1 = [
       'secrets',
       'rename',
       '-np',
       dataDir,
       `${vaultName}:${oldSecretName}`,
-      newSecretBaseName, // Use the simple base name
+      newSecretName,
     ];
-    const result = await testUtils.pkStdio(command, {
+    const result1 = await testUtils.pkStdio(command1, {
       env: { PK_PASSWORD: password },
       cwd: dataDir,
     });
-    expect(result.exitCode).toBe(0);
-    expect(result.stderr).toBe(''); // Expect no errors
+    expect(result1.exitCode).toBe(1);
     await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
       const list = await vaultOps.listSecrets(vault);
-      expect(list.sort()).toStrictEqual([newSecretBaseName]);
-      expect(list).not.toContain(oldSecretName);
-    });
-  });
-
-  // New test case for the fix
-  test('should rename secret when new name is a fully qualified path', async () => {
-    const vaultName = 'vaultFQRename' as VaultName; // Use a distinct vault name for the test
-    const vaultId = await polykeyAgent.vaultManager.createVault(vaultName);
-    const oldSecretName = 'oldSecretName';
-    const newSecretBaseName = 'newSecretNameByPath'; // The actual target base name
-    const secretContent = 'content for fully qualified path rename test';
-
-    // Add initial secret
-    await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
-      await vaultOps.addSecret(vault, oldSecretName, secretContent);
+      expect(list.sort()).toStrictEqual([oldSecretName]);
     });
 
-    // Construct the fully qualified path for the new secret name
-    // This format matches the problematic case: VaultName:/NewName
-    const newSecretFullyQualified = `${vaultName}:/${newSecretBaseName}`;
-
-    command = [
+    // Should pass if fully-qualified path is provided
+    const command2 = [
       'secrets',
       'rename',
       '-np',
       dataDir,
-      `${vaultName}:${oldSecretName}`, // Source secret path
-      newSecretFullyQualified, // New secret name as fully qualified path
+      `${vaultName}:${oldSecretName}`,
+      `${vaultName}:${newSecretName}`,
     ];
+    const result2 = await testUtils.pkStdio(command2, {
+      env: { PK_PASSWORD: password },
+      cwd: dataDir,
+    });
+    expect(result2.exitCode).toBe(0);
+    await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
+      const list = await vaultOps.listSecrets(vault);
+      expect(list.sort()).toStrictEqual([newSecretName]);
+    });
+  });
 
+  test('should fail renaming across vaults', async () => {
+    const vaultName1 = 'vault1' as VaultName;
+    const vaultName2 = 'vault2' as VaultName;
+    const vaultId1 = await polykeyAgent.vaultManager.createVault(vaultName1);
+    const vaultId2 = await polykeyAgent.vaultManager.createVault(vaultName2);
+    const oldSecretName = 'secretOld';
+    const newSecretName = 'secretNew';
+    const secretContent = 'this is the secret for simple rename';
+    await polykeyAgent.vaultManager.withVaults([vaultId1], async (vault) => {
+      await vaultOps.addSecret(vault, oldSecretName, secretContent);
+    });
+    const command = [
+      'secrets',
+      'rename',
+      '-np',
+      dataDir,
+      `${vaultName1}:${oldSecretName}`,
+      `${vaultName2}:${newSecretName}`,
+    ];
     const result = await testUtils.pkStdio(command, {
       env: { PK_PASSWORD: password },
       cwd: dataDir,
     });
-
-    expect(result.exitCode).toBe(0);
-    expect(result.stderr).toBe(''); // Expect no errors
-
-    // Verify the rename
-    await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
-      const secretsList = await vaultOps.listSecrets(vault);
-      expect(secretsList).toContain(newSecretBaseName); // Check for the base name
-      expect(secretsList).not.toContain(oldSecretName);
-      expect(secretsList.length).toBe(1); // Assuming only this secret is in the test vault
-    });
-  });
-
-  test('should not rename vault root', async () => {
-    const vaultName = 'vaultRootTest' as VaultName; // Use a distinct vault name
-    await polykeyAgent.vaultManager.createVault(vaultName);
-    // Attempting to rename the vault itself, or an empty path within it
-    command = [
-      'secrets',
-      'rename',
-      '-np',
-      dataDir,
-      `${vaultName}:/`,
-      'newNameForRoot',
-    ];
-    let result = await testUtils.pkStdio(command, {
-      env: { PK_PASSWORD: password },
-      cwd: dataDir,
-    });
-    expect(result.exitCode).not.toBe(0);
-    expect(result.stderr).toInclude('EPERM');
-
-    // Original test for trying to rename the vault name directly (which parseSecretPath handles as [vaultName, undefined, undefined])
-    // The `CommandRename` checks secretPath[1] == null, which covers `vaultName` (no colon) for the first arg.
-    command = ['secrets', 'rename', '-np', dataDir, vaultName, 'rename'];
-    result = await testUtils.pkStdio(command, {
-      env: { PK_PASSWORD: password },
-      cwd: dataDir,
-    });
-    expect(result.exitCode).not.toBe(0);
-    expect(result.stderr).toInclude('EPERM'); // This is because secretPath[1] will be undefined
+    expect(result.exitCode).toBe(1);
+    await polykeyAgent.vaultManager.withVaults(
+      [vaultId1, vaultId2],
+      async (vault1, vault2) => {
+        // The secret wasn't changed in the original place
+        const list1 = await vaultOps.listSecrets(vault1);
+        expect(list1.sort()).toStrictEqual([oldSecretName]);
+        // The target vault is also unchanged
+        const list2 = await vaultOps.listSecrets(vault2);
+        expect(list2.sort()).toStrictEqual([]);
+      },
+    );
   });
 });


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->
This PR addresses a bug in the polykey secrets rename <secretPath> <newSecretName> command where providing <newSecretName> as a fully qualified path (e.g., MyVault:/NewSecret) would cause an ENOENT error. This occurred because the underlying rename operation expects a simple base name for the new secret, not a full path.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #393 

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Change the `CommandRename.ts` script in src/secrets to allow for both simple base names `someSecret` and fully qualified paths `vaultName:/someSecret`

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
